### PR TITLE
Set charge of ReconstructedParticle with Cluster if possible

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -329,6 +329,11 @@ void DelphesEDM4HepConverter::fillReferenceCollection(const TClonesArray* delphe
         matchedReco->setMass(M_ELECTRON);
       }
 
+      // If we have a charge available, also set it
+      if constexpr (!std::is_same_v<DelphesT, Photon>) {
+        matchedReco->setCharge(delphesCand->Charge);
+      }
+
     } else {
       std::cerr << "**** WARNING: No matching ReconstructedParticle was found for a Delphes " << type << std::endl;
 

--- a/tests/src/compare_delphes_converter_outputs.cpp
+++ b/tests/src/compare_delphes_converter_outputs.cpp
@@ -208,6 +208,14 @@ void compareCollectionElements(const TClonesArray* delphesColl,
       std::cerr << "Delphes candidate " << i << " has different kinematics than edm4hep candidate in collection \'" << collName << "\'" << std::endl;
       std::exit(1);
     }
+
+    // Photons have no charge, so nothing to compare here
+    if constexpr (!std::is_same_v<DelphesT, Photon>) {
+      if (delphesCand->Charge != edm4hepCand.getCharge()) {
+        std::cerr << "Delphes candidate " << i << " has different charge than edm4hep candidate in collection \'" << collName << "\'" << std::endl;
+        std::exit(1);
+      }
+    }
   }
 }
 
@@ -237,6 +245,14 @@ void compareCollectionElements(const TClonesArray* delphesColl,
     if (!compareMCRelations(delphesCand, edm4hepCand, associations)) {
       std::cerr << "MC relations of candidate " << i << " are different between delphes and edm4hep output" << std::endl;
       std::exit(1);
+    }
+
+    // Towers / clusters have no charge, so nothing to compare here
+    if constexpr (!std::is_same_v<DelphesT, Tower>) {
+      if (delphesCand->Charge != edm4hepCand.getCharge()) {
+        std::cerr << "Delphes candidate " << i << " has different charge than edm4hep candidate in collection \'" << collName << "\'" << std::endl;
+        std::exit(1);
+      }
     }
   }
 }


### PR DESCRIPTION
Delphes Towers have no attached charges, but it is possible that a Tower is later identified as, e.g. an Electron, in which case we can at least set the charge of the ReconstructedParticle that we create out of the original Tower.