### PR TITLE
Relax matching criteria for jet constituents if necessary

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -382,6 +382,9 @@ std::optional<edm4hep::ReconstructedParticle> DelphesEDM4HepConverter::getMatchi
       if constexpr(std::is_same_v<DelphesT, Candidate>) {
         if (equalP4(getP4(it->second), delphesCand->Momentum)) {
           return it->second;
+        } else if (equalP4(getP4(it->second), delphesCand->Momentum, 1e-2, false)) {
+          // std::cout << "**** DEBUG: Kinematic matching successful after dropping energy matching and dropping momentum matching to percent level" << std::endl;
+          return it->second;
         }
       } else {
         if (equalP4(getP4(it->second), delphesCand->P4())) {

--- a/converter/src/delphesHelpers.h
+++ b/converter/src/delphesHelpers.h
@@ -30,11 +30,13 @@ inline LorentzVectorT getP4(const T& particle) {
 
 /**
  * Compare two 4-momentum vectors to be within a relative tolerance in the
- * energy and all momentum components
+ * energy and all momentum components. The energy requirement can be dropped on
+ * demand.
  */
 template<typename LVectorT, typename LVectorU>
-inline bool equalP4(const LVectorT& p1, const LVectorU& p2, double tol=1e-3) {
-  if (std::abs(p1.E() - p2.E()) / p1.E() > tol) return false;
+inline bool equalP4(const LVectorT& p1, const LVectorU& p2, double tol=1e-3,
+                    bool checkEnergy=true) {
+  if (checkEnergy && std::abs(p1.E() - p2.E()) / p1.E() > tol) return false;
   if (std::abs((p1.Px() - p2.Px()) / p1.Px()) > tol) return false;
   if (std::abs((p1.Py() - p2.Py()) / p1.Py()) > tol) return false;
   if (std::abs((p1.Pz() - p2.Pz()) / p1.Pz()) > tol) return false;


### PR DESCRIPTION
For some reason some of the jet constituents from delphes have slightly different kinematis during the conversion (but curiously no longer in the output), so if the first matching does not succeed, try again using a less strict matching; no energy and relaxed momentum matching.

Should fix all of the following warnings:

```
**** WARNING: No matching ReconstructedParticle was found for a Jet constituent
```