### PR TITLE
Install default output config to spack share dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ find_package(EDM4HEP)
 
 add_subdirectory(converter)
 add_subdirectory(standalone)
+add_subdirectory(examples)
 if(BUILD_FRAMEWORK)
   add_subdirectory(framework)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,5 @@
+#--- install the default output configuration to the shared directory which will
+#--- be picked up by the spack installation as $K4SIMDELPHES
+
+install(FILES edm4hep_output_config.tcl
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
BEGINRELEASENOTES
- Install the default output configuration into the `share/k4SimDelphes` directory, which is setup as `K4SIMDELPHES` by the [key4hep spack installation](https://github.com/key4hep/key4hep-spack/blob/71f3dd2231728a96f9dbe2dd815609119f8292e9/packages/k4simdelphes/package.py#L57).

ENDRELEASENOTES
