### PR TITLE
Remove trkcov unit scale factors obsolete with Delphes > v3.4.3pre11

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -489,33 +489,29 @@ edm4hep::Track convertTrack(Track const* cand, const double magFieldBz)
   
   TMatrixDSym covaFB = cand->CovarianceMatrix();
 
-  //This is needed as Delphes stores the units in the orignal format, so GeV and meters
-  double scale0 = 1.e3;
-  double scale1 = 1.;
-  //double scale2 = 1.e-3;
-  double scale2 = -2.* 1.e-3;    // CAREFUL: DELPHES USES THE HALF-CURVATURE
-  double scale3 = 1.e3;
-  double scale4 = 1.;
+  // needs to be applied to any covariance matrix element
+  // relating to curvature (index 2)
+  double scale2 = -2.;    // CAREFUL: DELPHES USES THE HALF-CURVATURE
+  
+  covMatrix[0]  = covaFB(0,0);
+  
+  covMatrix[1]  = covaFB(1,0);
+  covMatrix[2]  = covaFB(1,1);
 
-  covMatrix[0]  = covaFB(0,0) *scale0 * scale0;
+  covMatrix[3]  = covaFB(2,0) * scale2;
+  covMatrix[4]  = covaFB(2,1) * scale2;
+  covMatrix[5]  = covaFB(2,2) * scale2 * scale2;
   
-  covMatrix[1]  = covaFB(1,0) *scale1 * scale0;
-  covMatrix[2]  = covaFB(1,1) *scale1 * scale1;
-
-  covMatrix[3]  = covaFB(2,0) *scale2 * scale0;
-  covMatrix[4]  = covaFB(2,1) *scale2 * scale1;
-  covMatrix[5]  = covaFB(2,2) *scale2 * scale2;
+  covMatrix[6]  = covaFB(3,0);
+  covMatrix[7]  = covaFB(3,1);
+  covMatrix[8]  = covaFB(3,2) * scale2;
+  covMatrix[9]  = covaFB(3,3);
   
-  covMatrix[6]  = covaFB(3,0) *scale3 * scale0;
-  covMatrix[7]  = covaFB(3,1) *scale3 * scale1;
-  covMatrix[8]  = covaFB(3,2) *scale3 * scale2;
-  covMatrix[9]  = covaFB(3,3) *scale3 * scale3;
-  
-  covMatrix[10] = covaFB(4,0) *scale4 * scale0;
-  covMatrix[11] = covaFB(4,1) *scale4 * scale1;
-  covMatrix[12] = covaFB(4,2) *scale4 * scale2;
-  covMatrix[13] = covaFB(4,3) *scale4 * scale3;
-  covMatrix[14] = covaFB(4,4) *scale4 * scale4;
+  covMatrix[10] = covaFB(4,0);
+  covMatrix[11] = covaFB(4,1);
+  covMatrix[12] = covaFB(4,2) * scale2;
+  covMatrix[13] = covaFB(4,3);
+  covMatrix[14] = covaFB(4,4);
 
   track.addToTrackStates(trackState);
 


### PR DESCRIPTION
- [ ] Add a test for the units
- [ ] Require Delphes >= 3.5.0 in cmake