### PR TITLE
Fix unit test crashes and make them more robust

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -408,8 +408,8 @@ std::optional<edm4hep::ReconstructedParticle> DelphesEDM4HepConverter::getMatchi
       const auto edm4Mom = getP4(it->second);
       if (equalP4(edm4Mom, delphes4Mom)) {
         return it->second;
-      } else if (equalP4(edm4Mom, delphes4Mom, 1e-2, false)) {
-        // std::cout << "**** DEBUG: Kinematic matching successful after dropping energy matching and dropping momentum matching to percent level" << std::endl;
+      } else if (equalP4(edm4Mom, delphes4Mom, 1e-5, false)) {
+        // std::cout << "**** DEBUG: Kinematic matching successful after dropping energy matching" << std::endl;
         return it->second;
       }
     }

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -330,9 +330,9 @@ void DelphesEDM4HepConverter::fillReferenceCollection(const TClonesArray* delphe
 
   for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
     auto* delphesCand = static_cast<DelphesT*>(delphesCollection->At(iCand));
-    auto recoRef = collection->create();
 
     if (auto matchedReco = getMatchingReco(delphesCand)) {
+      auto recoRef = collection->create();
       recoRef.setParticle(*matchedReco);
       // if we have an electron or muon we update the mass as well here
       if constexpr (std::is_same_v<DelphesT, Muon>) {

--- a/tests/src/compare_delphes_converter_outputs.cpp
+++ b/tests/src/compare_delphes_converter_outputs.cpp
@@ -28,11 +28,10 @@
 template<typename DelphesT, typename EDM4HepT>
 bool compareKinematics(const DelphesT* delphesCand, const EDM4HepT& edm4hepCand) {
   using namespace k4SimDelphes;
-  if (!equalP4(delphesCand->P4(), getP4(edm4hepCand))) {
-    return false;
-  }
-
-  return true;
+  // Use the same matching criteria as in the converter: First try with all
+  // components, if that doesn't work try again without the energy
+  return equalP4(delphesCand->P4(), getP4(edm4hepCand)) ||  \
+    equalP4(delphesCand->P4(), getP4(edm4hepCand), 1e-5, false);
 }
 
 /**
@@ -274,7 +273,7 @@ void compareJets(const TClonesArray* delphesColl,
     }
 
     if (delphesCand->Constituents.GetEntries() != edm4hepCand.getParticles().size()) {
-      std::cerr << "Number of Jet constitutents differs between delphes and edm4hep output: "
+      std::cerr << "Number of Jet constitutents in Jet " << i << " differs between delphes and edm4hep output: "
                 << delphesCand->Constituents.GetEntries() << " vs " <<  edm4hepCand.getParticles().size() << std::endl;
       std::exit(1);
     }

--- a/tests/testDriver.sh
+++ b/tests/testDriver.sh
@@ -6,9 +6,65 @@ EDM4HEP_CMD=${1}
 # can be inferred quite easily
 DELPHES_CMD=${EDM4HEP_CMD/_EDM4HEP/}
 
-DELPHES_CARD=${2}
+DELPHES_CARD_IN=${2}
 OUTPUT_CONFIG=${3}
 OUTPUT_FILE=${4}
+
+DELPHES_CARD=$(pwd)/test_$(basename ${DELPHES_CARD_IN})
+
+# Keep track on whether this has been enabled from the calling site
+xtrace_on=$(shopt -qo xtrace && echo "yes")
+set +x # Don't need this explicit detailed output for these replacements
+
+# Record the seeds to a file so that we can display them again at script exit if
+# something goes wrong for a more convenient way of finding this infomration in
+# the vast output of these tests
+RANDOM_SEEDS_FILE=$(mktemp $(pwd)/random_seeds.XXXXXXXX)
+function seeds_file_cleanup() {
+    cat ${RANDOM_SEEDS_FILE}
+    rm ${RANDOM_SEEDS_FILE}
+}
+trap seeds_file_cleanup EXIT
+
+# In order to not have the tests only work with one specific RandomSeed we
+# generate a random seed here (unless we override it via the DELPHES_RANDOM_SEED
+# env variable) and inject that into the delphes card. This allows us to still
+# reproduce the same test run after it has failed because we can see the used
+# random seed in the output.
+function random_seed_delphes_card() {
+    local card_file=${1}
+    local out_file=${2}
+    if [ "X${DELPHES_RANDOM_SEED}" = "X" ]; then
+        local seed=${RANDOM}
+    else
+        local seed=${DELPHES_RANDOM_SEED}
+    fi
+    echo "RANDOM SEED FOR DELPHES CARD = ${seed}" | tee -a ${RANDOM_SEEDS_FILE}
+    grep "set RandomSeed" ${card_file} > /dev/null 2>&1 && \
+        sed "s/set RandomSeed .*/set RandomSeed ${seed}/" ${card_file} > ${out_file}|| \
+        sed "/set MaxEvents/a set RandomSeed ${seed}" ${card_file} > ${out_file}
+}
+random_seed_delphes_card ${DELPHES_CARD_IN} ${DELPHES_CARD}
+
+# Similar to the delphes random seed we generate one for the pythia command, can
+# be overridden with PYTHIA_RANDOM_SEED env variable
+function random_seed_pythia_cmd() {
+    local cmd_file=${1}
+    local out_file=${2}
+    if [ "X${PYTHIA_RANDOM_SEED}" = "X" ]; then
+        local seed=${RANDOM}
+    else
+        local seed=${PYTHIA_RANDOM_SEED}
+    fi
+    echo "RANDOM SEED FOR PYTHIA CMD = ${seed}" | tee -a ${RANDOM_SEEDS_FILE}
+    grep "Random:seed" ${cmd_file} > /dev/null 2>&1 && \
+        sed "s/Random:seed = .*/Random:seed = ${seed}/" ${cmd_file} > ${out_file} || \
+        sed "/Main:numberOfEvents/a Random:setSeed = on\nRandom:seed = ${seed}" ${cmd_file} > ${out_file}
+}
+
+# restore the xtrace setup
+[[ ${xtrace_on} = "yes" ]] && set -x
+
 # Derive the outputfile name for delphes from the output file name of the
 # edm4hep run
 DELPHES_OUTPUT_FILE=${OUTPUT_FILE/.root/_delphes.root}
@@ -21,8 +77,13 @@ REST_ARGS=${@}
 # Pythia needs special treatment here because the clargs do not follow the same
 # convention as for the others
 if [ ${DELPHES_CMD/Delphes/} = 'Pythia8' ]; then
-    ${EDM4HEP_CMD} ${DELPHES_CARD} ${OUTPUT_CONFIG} ${REST_ARGS} ${OUTPUT_FILE}
-    ${DELPHES_CMD} ${DELPHES_CARD} ${REST_ARGS} ${DELPHES_OUTPUT_FILE}
+    PYTHIA_CMD=$(pwd)/test_$(basename ${REST_ARGS})
+    set +x
+    random_seed_pythia_cmd ${REST_ARGS} ${PYTHIA_CMD}
+    [[ ${xtrace_on} = "yes" ]] && set -x
+
+    ${EDM4HEP_CMD} ${DELPHES_CARD} ${OUTPUT_CONFIG} ${PYTHIA_CMD} ${OUTPUT_FILE}
+    ${DELPHES_CMD} ${DELPHES_CARD} ${PYTHIA_CMD} ${DELPHES_OUTPUT_FILE}
 else
     ${EDM4HEP_CMD} ${DELPHES_CARD} ${OUTPUT_CONFIG} ${OUTPUT_FILE} ${REST_ARGS}
     ${DELPHES_CMD} ${DELPHES_CARD} ${DELPHES_OUTPUT_FILE} ${REST_ARGS}


### PR DESCRIPTION
BEGINRELEASENOTES
- Only create `RecoParticleRef` objects if there is a valid reco particle to point to, to avoid possible nullptr access when reading the created files.
- Make the kinematic matching more robust and allow for a less strict second attempt If a strict kinematic matching (dropping the energy from matching) is not possible the first time.
- Make the integration tests that compare the original delphes output to the converted output less dependent on an specific random seed by seeding each test run with random random seeds, but record them so that it becomes possible to reproduce a failure with them.
  
ENDRELEASENOTES

Fixes #42 

Even with the relaxed matching there are still cases where no valid reco particle can be found. For me locally they seem to happen in around 1 of roughly 10k events.
- [ ] Find out why this happens and try to fix it, such that the tests can be run reliably.
