### PR TITLE
Cleanup cmake dependency handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,18 +73,46 @@ endif()
 
 
 #--- Non-optional Dependencies ------------------------------------------------
-find_package(Delphes)
-find_package(EDM4HEP)
+find_package(Delphes REQUIRED)
+find_package(EDM4HEP REQUIRED)
+
+#--- optional dependencies
+if(BUILD_PYTHIA_READER OR BUILD_EVTGEN_READER)
+  find_package(Pythia8 REQUIRED)
+
+  if(BUILD_EVTGEN_READER)
+    if(PYTHIA8_VERSION VERSION_LESS 300)
+      message("ERROR: Cannot build EVTGEN Reader. PYTHIA8300 or newer required. ")
+    endif()
+
+    find_package(EvtGen REQUIRED)
+  endif()
+endif()
 
 #--- Code Sub-directories -----------------------------------------------------
 add_subdirectory(converter)
 add_subdirectory(standalone)
 add_subdirectory(examples)
+
+
 if(BUILD_FRAMEWORK)
+  find_package(Gaudi REQUIRED) # Do not depend on implicit find via k4FWCore
+  find_package(k4FWCore REQUIRED)
+  if (BUILD_TESTING)
+    find_package(k4Gen REQUIRED) # Finds Gaudi, etc. again
+  endif()
+
   add_subdirectory(framework)
 endif()
+
 if(BUILD_TESTING)
   option(BUILD_UNITTESTS "Build the unittest for k4SimDelphes" ON)
+  if(BUILD_UNITTESTS)
+    if(USE_EXTERNAL_CATCH2)
+      find_package(Catch2 REQUIRED)
+    endif()
+  endif()
+
   add_subdirectory(tests)
 endif()
 

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,8 +1,4 @@
 
 #### k4SimDelphes: Delphes integrated in the Gaudi framework
 
-# dependencies
-find_package(Gaudi)
-find_package(k4FWCore)
-
 add_subdirectory(k4SimDelphes)

--- a/framework/k4SimDelphes/CMakeLists.txt
+++ b/framework/k4SimDelphes/CMakeLists.txt
@@ -18,7 +18,6 @@ install(DIRECTORY examples DESTINATION share/${PROJECT_NAME})
 
 #--- Testing
 if(BUILD_TESTING)
-  find_package(k4Gen)
 
   if(TARGET k4Gen::k4Gen)
     add_test(NAME k4SimDelphesAlgBasicTest

--- a/framework/k4SimDelphes/CMakeLists.txt
+++ b/framework/k4SimDelphes/CMakeLists.txt
@@ -19,13 +19,20 @@ install(DIRECTORY examples DESTINATION share/${PROJECT_NAME})
 #--- Testing
 if(BUILD_TESTING)
 
+  #--- The genConf directory has been renamed to genConfDir in Gaudi 35r1
+  #--- See https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1158
+  set(GAUDI_GENCONF_DIR "genConfDir")
+  if (${Gaudi_VERSION} VERSION_LESS 35.1)
+    set(GAUDI_GENCONF_DIR "genConf")
+  endif()
+
   if(TARGET k4Gen::k4Gen)
     add_test(NAME k4SimDelphesAlgBasicTest
              WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/examples/options
              COMMAND  k4run k4simdelphesalg.py)
     # set up gaudi environment for tests
     set_property(TEST k4SimDelphesAlgBasicTest APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/framework/k4SimDelphes:$<TARGET_FILE_DIR:k4Gen::k4Gen>:$ENV{LD_LIBRARY_PATH}"
-    "PYTHONPATH=$<TARGET_FILE_DIR:k4Gen::k4Gen>/../python:${CMAKE_BINARY_DIR}/framework/k4SimDelphes/genConf:$ENV{PYTHONPATH}"
+    "PYTHONPATH=$<TARGET_FILE_DIR:k4Gen::k4Gen>/../python:${CMAKE_BINARY_DIR}/framework/k4SimDelphes/${GAUDI_GENCONF_DIR}:$ENV{PYTHONPATH}"
     )
 
   else()

--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -1,7 +1,3 @@
-
-
-
-
 # build executable and put it into bin/
 add_executable(DelphesROOT_EDM4HEP src/DelphesROOT_EDM4HEP.cpp)
 target_link_libraries(DelphesROOT_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO ROOT::Physics)
@@ -20,7 +16,6 @@ target_link_libraries(DelphesSTDHEP_EDM4HEP DelphesEDM4HepConverter podio::podio
 install(TARGETS DelphesSTDHEP_EDM4HEP DESTINATION bin)
 
 if(BUILD_PYTHIA_READER)
-  find_package(Pythia8 REQUIRED)
   add_executable(DelphesPythia8_EDM4HEP src/DelphesPythia8_EDM4HEP.cpp)
   target_include_directories(DelphesPythia8_EDM4HEP PRIVATE ${PYTHIA8_INCLUDE_DIRS})
   target_link_libraries(DelphesPythia8_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO ${PYTHIA8_LIBRARIES} ${DELPHES_LIBRARY})
@@ -28,25 +23,19 @@ if(BUILD_PYTHIA_READER)
 endif()
 
 if(BUILD_EVTGEN_READER)
-  find_package(EvtGen REQUIRED)
-  find_package(Pythia8 REQUIRED)
-  if(PYTHIA8_VERSION VERSION_LESS 300)
-    message("ERROR: Cannot build EVTGEN Reader. PYTHIA8300 or newer required. ")
-  else()
-    add_library(PythiaEvtGen_Interface SHARED src/PythiaEvtGen_Interface.cc)
-    target_include_directories(PythiaEvtGen_Interface PRIVATE ${PYTHIA8_INCLUDE_DIRS} ${EVTGEN_INCLUDE_DIR})
-    target_link_libraries(PythiaEvtGen_Interface ${PYTHIA8_LIBRARIES} ${EVTGEN_LIBRARIES})
-    install(TARGETS PythiaEvtGen_Interface DESTINATION ${CMAKE_INSTALL_LIBDIR})
+  add_library(PythiaEvtGen_Interface SHARED src/PythiaEvtGen_Interface.cc)
+  target_include_directories(PythiaEvtGen_Interface PRIVATE ${PYTHIA8_INCLUDE_DIRS} ${EVTGEN_INCLUDE_DIR})
+  target_link_libraries(PythiaEvtGen_Interface ${PYTHIA8_LIBRARIES} ${EVTGEN_LIBRARIES})
+  install(TARGETS PythiaEvtGen_Interface DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-    add_executable(DelphesPythia8EvtGen_EDM4HEP src/DelphesPythia8EvtGen_EDM4HEP.cpp)
-    add_executable(DelphesPythia8EvtGen_EDM4HEP_k4Interface src/DelphesPythia8EvtGen_EDM4HEP_k4Interface.cpp)
+  add_executable(DelphesPythia8EvtGen_EDM4HEP src/DelphesPythia8EvtGen_EDM4HEP.cpp)
+  add_executable(DelphesPythia8EvtGen_EDM4HEP_k4Interface src/DelphesPythia8EvtGen_EDM4HEP_k4Interface.cpp)
 
-    target_include_directories(DelphesPythia8EvtGen_EDM4HEP PRIVATE ${PYTHIA8_INCLUDE_DIRS} ${EVTGEN_INCLUDE_DIR})
-    target_link_libraries(DelphesPythia8EvtGen_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO ${PYTHIA8_LIBRARIES} ${DELPHES_LIBRARY} ${EVTGEN_LIBRARIES})
-    install(TARGETS DelphesPythia8EvtGen_EDM4HEP DESTINATION bin)
+  target_include_directories(DelphesPythia8EvtGen_EDM4HEP PRIVATE ${PYTHIA8_INCLUDE_DIRS} ${EVTGEN_INCLUDE_DIR})
+  target_link_libraries(DelphesPythia8EvtGen_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO ${PYTHIA8_LIBRARIES} ${DELPHES_LIBRARY} ${EVTGEN_LIBRARIES})
+  install(TARGETS DelphesPythia8EvtGen_EDM4HEP DESTINATION bin)
 
-    target_include_directories(DelphesPythia8EvtGen_EDM4HEP_k4Interface PRIVATE ${PYTHIA8_INCLUDE_DIRS} ${EVTGEN_INCLUDE_DIR})
-    target_link_libraries(DelphesPythia8EvtGen_EDM4HEP_k4Interface PythiaEvtGen_Interface DelphesEDM4HepConverter podio::podioRootIO ${PYTHIA8_LIBRARIES} ${DELPHES_LIBRARY} ${EVTGEN_LIBRARIES})
-    install(TARGETS DelphesPythia8EvtGen_EDM4HEP_k4Interface DESTINATION bin)
-  endif()
+  target_include_directories(DelphesPythia8EvtGen_EDM4HEP_k4Interface PRIVATE ${PYTHIA8_INCLUDE_DIRS} ${EVTGEN_INCLUDE_DIR})
+  target_link_libraries(DelphesPythia8EvtGen_EDM4HEP_k4Interface PythiaEvtGen_Interface DelphesEDM4HepConverter podio::podioRootIO ${PYTHIA8_LIBRARIES} ${DELPHES_LIBRARY} ${EVTGEN_LIBRARIES})
+  install(TARGETS DelphesPythia8EvtGen_EDM4HEP_k4Interface DESTINATION bin)
 endif()

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,7 +1,5 @@
 
-if(USE_EXTERNAL_CATCH2)
-  find_package(Catch2 REQUIRED)
-else()
+if(NOT USE_EXTERNAL_CATCH2)
   message("Fetching local copy of Catch2 library for unit-tests...")
   Include(FetchContent)
   FetchContent_Declare(
@@ -11,7 +9,6 @@ else()
   FetchContent_MakeAvailable(Catch2)
   set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})
 endif()
-
 
 add_executable(k4SimDelphesTests   tests.cpp tests_edm4hepdelphesconverter.cpp)
 target_link_libraries(k4SimDelphesTests 
@@ -29,4 +26,3 @@ include(CTest)
 include(Catch)
 catch_discover_tests(k4SimDelphesTests
                     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../)
-


### PR DESCRIPTION
BEGINRELEASENOTES
- Move all `find_package` calls to top-level `CMakeLists.txt` and remove duplicate calls.
- Fix `PYTHONPATH` environment for framework tests

ENDRELEASENOTES

Fixes #37 (as far as it can be fixed)

The remaining duplicate entries in the cmake output cannot be fixed, because dependencies might be looking for their dependencies again (e.g. `k4FWCore` looks for `Gaudi`, but `k4Gen` looks for `k4FWCore` and `Gaudi` again). I have also kept `Gaudi` as explicit dependency to not depend on the implicit dependency via `k4FWCore`.
