### PR TITLE
[cmake] Make FindPythia8 more robust

### DIFF
--- a/cmake/FindPythia8.cmake
+++ b/cmake/FindPythia8.cmake
@@ -10,29 +10,50 @@
 #  PYTHIA8_lhapdfdummy_LIBRARY
 #  PYTHIA8_LIBRARIES (not cached) : for PYTHIA8_VERSION < 200 includes 3 libraries above; not to be used if lhapdf is used
 
+set(_pythia8_dirs
+    ${PYTHIA8}
+    $ENV{PYTHIA8}
+    ${PYTHIA8_DIR}
+    $ENV{PYTHIA8_DIR}
+    ${PYTHIA8_ROOT_DIR}
+)
 
-find_path(PYTHIA8_INCLUDE_DIR Pythia.h Pythia8/Pythia.h
-          HINTS $ENV{PYTHIA8}/include ${PYTHIA8_ROOT_DIR}/include)
+find_path(PYTHIA8_INCLUDE_DIR
+          NAMES Pythia8/Pythia.h
+          HINTS ${_pythia8_dirs}
+          PATH_SUFFIXES include include/Pythia8
+          NO_DEFAULT_PATH)
+
 find_path(PYTHIA8_XML_DIR Version.xml
-          HINTS $ENV{PYTHIA8}/xmldoc ${PYTHIA8_ROOT_DIR}/xmldoc $ENV{PYTHIA8}/share/Pythia8/xmldoc ${PYTHIA8_ROOT_DIR}/share/Pythia8/xmldoc)
+          HINTS ${_pythia8_dirs}
+          PATH_SUFFIXES xmldoc share/Pythia8/xmldoc
+          NO_DEFAULT_PATH)
 
 message(STATUS "xml path: ${PYTHIA8_XML_DIR}")
 
-#file(READ ${PYTHIA8_INCLUDE_DIR}/../xmldoc/Version.xml versionstr)
 file(READ ${PYTHIA8_XML_DIR}/Version.xml versionstr)
 string(REGEX REPLACE ".*Pythia:versionNumber.*default.*[0-9][.]([0-9]+).*" "\\1" PYTHIA8_VERSION "${versionstr}")
 
 message(STATUS "pythia8 version extracted: ${PYTHIA8_VERSION}")
 
-find_library(PYTHIA8_LIBRARY NAMES pythia8 Pythia8
-             HINTS $ENV{PYTHIA8_ROOT_DIR}/lib ${PYTHIA8_ROOT_DIR}/lib)
+find_library(PYTHIA8_LIBRARY
+             NAMES pythia8 Pythia8
+             HINTS ${_pythia8_dirs}
+             PATH_SUFFIXES lib
+             NO_DEFAULT_PATH)
 
 if(PYTHIA8_VERSION VERSION_LESS 200)
-  find_library(PYTHIA8_hepmcinterface_LIBRARY NAMES hepmcinterface pythia8tohepmc
-               HINTS $ENV{PYTHIA8_ROOT_DIR}/lib ${PYTHIA8_ROOT_DIR}/lib)
+  find_library(PYTHIA8_hepmcinterface_LIBRARY
+               NAMES hepmcinterface pythia8tohepmc
+               HINTS ${_pythia8_dirs}
+               PATH_SUFFIXES lib
+               NO_DEFAULT_PATH)
 
-  find_library(PYTHIA8_lhapdfdummy_LIBRARY NAMES lhapdfdummy
-               HINTS $ENV{PYTHIA8_ROOT_DIR}/lib ${PYTHIA8_ROOT_DIR}/lib)
+  find_library(PYTHIA8_lhapdfdummy_LIBRARY
+               NAMES lhapdfdummy
+               HINTS ${_pythia8_dirs}
+               PATH_SUFFIXES lib
+               NO_DEFAULT_PATH)
 
   set(PYTHIA8_LIBRARIES ${PYTHIA8_LIBRARY} ${PYTHIA8_hepmcinterface_LIBRARY} ${PYTHIA8_lhapdfdummy_LIBRARY})
 else()


### PR DESCRIPTION
Handling more similar to the one in delphes, so that we can find Pythia8 if delphes can find it.


BEGINRELEASENOTES
- Make `FindPythia8.cmake` more robust such that it behaves similar to the one that is shipped with Delphes.

ENDRELEASENOTES
