### PR TITLE
[wip] Use reference collections instead of RecoParticleRef

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -103,7 +103,7 @@ private:
   void registerGlobalCollections();
 
   template<typename CollectionT>
-  void createCollection(std::string_view const name);
+  void createCollection(std::string_view const name, bool makeRefColl=false);
 
   // cannot mark DelphesT as const, because for Candidate* the GetCandidates()
   // method is not marked as const.
@@ -130,9 +130,10 @@ private:
 };
 
 template<typename CollectionT>
-void DelphesEDM4HepConverter::createCollection(std::string_view name) {
+void DelphesEDM4HepConverter::createCollection(std::string_view name, bool makeRefColl) {
   std::string nameStr(name);
   CollectionT* col = new CollectionT();
+  col->setSubsetCollection(makeRefColl);
   m_collections.emplace(name, col);
 }
 

--- a/tests/src/compare_delphes_converter_outputs.cpp
+++ b/tests/src/compare_delphes_converter_outputs.cpp
@@ -2,7 +2,6 @@
 
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
-#include "edm4hep/RecoParticleRefCollection.h"
 #include "edm4hep/MCRecoParticleAssociationCollection.h"
 
 #include "podio/ROOTReader.h"
@@ -221,11 +220,11 @@ void compareCollectionElements(const TClonesArray* delphesColl,
  */
 template<typename DelphesT>
 void compareCollectionElements(const TClonesArray* delphesColl,
-                               const edm4hep::RecoParticleRefCollection& edm4hepColl,
+                               const edm4hep::ReconstructedParticleCollection& edm4hepColl,
                                const std::string collName) {
   for (int i = 0; i < delphesColl->GetEntries(); ++i) {
     const auto* delphesCand = static_cast<DelphesT*>(delphesColl->At(i));
-    const auto edm4hepCand = edm4hepColl[i].getParticle();
+    const auto edm4hepCand = edm4hepColl[i];
     assertSameKinematics(delphesCand, edm4hepCand, stdErrorMessage, collName, i);
 
     // Photons have no charge, so nothing to compare here
@@ -360,15 +359,15 @@ int main(int argc, char* argv[]) {
     compareCollectionsBasic(genParticleCollDelphes, genParticleColl, "Particle");
     compareCollectionElements(genParticleCollDelphes, genParticleColl, "Particle");
 
-    auto& electronColl = store.get<edm4hep::RecoParticleRefCollection>("Electron");
+    auto& electronColl = store.get<edm4hep::ReconstructedParticleCollection>("Electron");
     compareCollectionsBasic(electronCollDelphes, electronColl, "Electron");
     compareCollectionElements<Electron>(electronCollDelphes, electronColl, "Electron");
 
-    auto& muonColl = store.get<edm4hep::RecoParticleRefCollection>("Muon");
+    auto& muonColl = store.get<edm4hep::ReconstructedParticleCollection>("Muon");
     compareCollectionsBasic(muonCollDelphes, muonColl, "Muon");
     compareCollectionElements<Muon>(muonCollDelphes, muonColl, "Muon");
 
-    auto& photonColl = store.get<edm4hep::RecoParticleRefCollection>("Photon");
+    auto& photonColl = store.get<edm4hep::ReconstructedParticleCollection>("Photon");
     compareCollectionsBasic(photonCollDelphes, photonColl, "Photon");
     compareCollectionElements<Photon>(photonCollDelphes, photonColl, "Photon");
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch to reference collections instead of using `RecoParticleRef` (see key4hep/EDM4hep#116, and AIDASoft/podio#197)

ENDRELEASENOTES

Needs both of the mentioned PRs to be merged first.

Includes #59 ~and #53~ at the moment, as I expect those will go in first. But can be removed if necessary.