### PR TITLE
Make the standalone executables return 0 for user requested help

### DIFF
--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -29,6 +29,12 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
   auto* modularDelphes = new Delphes("Delphes");
   const auto outputFile = inputReader.init(modularDelphes, argc, argv);
   if (outputFile.empty()) {
+    // Check if the user requested the help, and print the usage message and
+    // return succesfully in that case
+    if (argv[1] == std::string_view("--help") || argv[1] == std::string_view("-h")) {
+      std::cout << inputReader.getUsage() << std::endl;
+      return 0;
+    }
     std::cerr << inputReader.getUsage() << std::endl;
     return 1;
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the standalone executables print the usage message to stdout and return 0 if the user specifically asked for this message via the `--help` or `-h` argument

ENDRELEASENOTES
