### PR TITLE
add the  radius of the  innermost hit to the tracks

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -531,6 +531,10 @@ edm4hep::Track convertTrack(Track const* cand, const double magFieldBz)
 
   track.addToTrackStates(trackState);
 
+  float radiusOfInnermostHit = sqrt( pow( cand->XFirstHit, 2) + pow( cand->YFirstHit, 2) );
+  track.setRadiusOfInnermostHit( radiusOfInnermostHit );
+
+
   return track;
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- to be used with Delphes 3.5.1pre02 or later
- fill the "radiusOfInnermostHit" member of edm4hep tracks using the position of the first hit, which is now part of the Delphes tracks

ENDRELEASENOTES
