### PR TITLE
Make the UserDataCollections use the same mechanism as other collections

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -3,7 +3,6 @@
 
 // podio
 #include "podio/CollectionBase.h"
-#include "podio/UserDataCollection.h"
 
 // edm4hep
 #include "edm4hep/MCParticle.h"
@@ -75,10 +74,6 @@ namespace k4SimDelphes {
 
     inline const std::unordered_map<std::string, podio::CollectionBase*>& getCollections() { return m_collections; }
 
-    inline std::unordered_map<std::string, podio::UserDataCollection<float>*> getUserDataCollections() {
-      return m_userdatacollections;
-    }
-
     void processParticles(const TClonesArray* delphesCollection, std::string const& branch);
     void processTracks(const TClonesArray* delphesCollection, std::string const& branch);
     void processClusters(const TClonesArray* delphesCollection, std::string const& branch);
@@ -116,10 +111,9 @@ namespace k4SimDelphes {
 
     using ProcessFunction = void (DelphesEDM4HepConverter::*)(const TClonesArray*, std::string const&);
 
-    std::vector<BranchSettings>                                        m_branches;
-    std::unordered_map<std::string, podio::CollectionBase*>            m_collections;
-    std::unordered_map<std::string, podio::UserDataCollection<float>*> m_userdatacollections;
-    std::unordered_map<std::string_view, ProcessFunction>              m_processFunctions;
+    std::vector<BranchSettings>                             m_branches;
+    std::unordered_map<std::string, podio::CollectionBase*> m_collections;
+    std::unordered_map<std::string_view, ProcessFunction>   m_processFunctions;
 
     double m_magneticFieldBz;  // necessary for determining track parameters
 

--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -44,7 +44,7 @@ namespace k4SimDelphes {
   /**
    * Classes that will be stored as TrackerHits
    */
-  constexpr std::string_view TRACKERHIT_OUTPUT_NAME = "TrackerHits";
+  constexpr auto TRACKERHIT_OUTPUT_NAME = "TrackerHits";
 
   struct BranchSettings {
     std::string input;
@@ -73,26 +73,27 @@ namespace k4SimDelphes {
 
     void process(TTree* delphesTree);
 
-    inline std::unordered_map<std::string_view, podio::CollectionBase*> getCollections() { return m_collections; }
+    inline const std::unordered_map<std::string, podio::CollectionBase*>& getCollections() { return m_collections; }
 
     inline std::unordered_map<std::string, podio::UserDataCollection<float>*> getUserDataCollections() {
       return m_userdatacollections;
     }
-    void processParticles(const TClonesArray* delphesCollection, std::string_view const branch);
-    void processTracks(const TClonesArray* delphesCollection, std::string_view const branch);
-    void processClusters(const TClonesArray* delphesCollection, std::string_view const branch);
-    void processJets(const TClonesArray* delphesCollection, std::string_view const branch);
-    void processPhotons(const TClonesArray* delphesCollection, std::string_view const branch) {
+
+    void processParticles(const TClonesArray* delphesCollection, std::string const& branch);
+    void processTracks(const TClonesArray* delphesCollection, std::string const& branch);
+    void processClusters(const TClonesArray* delphesCollection, std::string const& branch);
+    void processJets(const TClonesArray* delphesCollection, std::string const& branch);
+    void processPhotons(const TClonesArray* delphesCollection, std::string const& branch) {
       fillReferenceCollection<Photon>(delphesCollection, branch, "photon");
     }
 
-    void processMissingET(const TClonesArray* delphesCollection, std::string_view const branch);
-    void processScalarHT(const TClonesArray* delphesCollection, std::string_view const branch);
+    void processMissingET(const TClonesArray* delphesCollection, std::string const& branch);
+    void processScalarHT(const TClonesArray* delphesCollection, std::string const& branch);
 
-    void processMuons(const TClonesArray* delphesCollection, std::string_view const branch) {
+    void processMuons(const TClonesArray* delphesCollection, std::string const& branch) {
       fillReferenceCollection<Muon>(delphesCollection, branch, "muon");
     }
-    void processElectrons(const TClonesArray* delphesCollection, std::string_view const branch) {
+    void processElectrons(const TClonesArray* delphesCollection, std::string const& branch) {
       fillReferenceCollection<Electron>(delphesCollection, branch, "electron");
     }
 
@@ -101,22 +102,22 @@ namespace k4SimDelphes {
 
   private:
     template <typename DelphesT>
-    void fillReferenceCollection(const TClonesArray* delphesCollection, std::string_view const branch,
+    void fillReferenceCollection(const TClonesArray* delphesCollection, std::string const& branch,
                                  const std::string_view type);
 
     void registerGlobalCollections();
 
-    template <typename CollectionT> void createCollection(std::string_view const name, bool makeRefColl = false);
+    template <typename CollectionT> void createCollection(std::string const& name, bool makeRefColl = false);
 
     // cannot mark DelphesT as const, because for Candidate* the GetCandidates()
     // method is not marked as const.
     template <typename DelphesT>
     std::optional<edm4hep::MutableReconstructedParticle> getMatchingReco(/*const*/ DelphesT* delphesCand) const;
 
-    using ProcessFunction = void (DelphesEDM4HepConverter::*)(const TClonesArray*, std::string_view const);
+    using ProcessFunction = void (DelphesEDM4HepConverter::*)(const TClonesArray*, std::string const&);
 
     std::vector<BranchSettings>                                        m_branches;
-    std::unordered_map<std::string_view, podio::CollectionBase*>       m_collections;
+    std::unordered_map<std::string, podio::CollectionBase*>            m_collections;
     std::unordered_map<std::string, podio::UserDataCollection<float>*> m_userdatacollections;
     std::unordered_map<std::string_view, ProcessFunction>              m_processFunctions;
 
@@ -134,8 +135,7 @@ namespace k4SimDelphes {
   };
 
   template <typename CollectionT>
-  void DelphesEDM4HepConverter::createCollection(std::string_view name, bool makeRefColl) {
-    std::string  nameStr(name);
+  void DelphesEDM4HepConverter::createCollection(std::string const& name, bool makeRefColl) {
     CollectionT* col = new CollectionT();
     col->setSubsetCollection(makeRefColl);
     m_collections.emplace(name, col);

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -96,8 +96,8 @@ namespace k4SimDelphes {
           contains(RECO_TRACK_OUTPUT, branch.className.c_str())) {
         registerGlobalCollections();
         createCollection<edm4hep::TrackCollection>(branch.name);
-        m_userdatacollections.emplace(std::string(branch.name) + "_dNdx", new podio::UserDataCollection<float>());
-        m_userdatacollections.emplace(std::string(branch.name) + "_L", new podio::UserDataCollection<float>());
+        createCollection<podio::UserDataCollection<float>>(branch.name + "_dNdx");
+        createCollection<podio::UserDataCollection<float>>(branch.name + "_L");
         m_processFunctions.emplace(branch.name, &DelphesEDM4HepConverter::processTracks);
       }
 
@@ -193,8 +193,8 @@ namespace k4SimDelphes {
     auto* particleCollection = static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[m_recoCollName]);
     auto* trackCollection    = static_cast<edm4hep::TrackCollection*>(m_collections[branch]);
     //UserData for overflowing information
-    podio::UserDataCollection<float>* dndxCollection       = m_userdatacollections.at(std::string(branch) + "_dNdx");
-    podio::UserDataCollection<float>* pathLengthCollection = m_userdatacollections.at(std::string(branch) + "_L");
+    auto* dndxCollection       = static_cast<podio::UserDataCollection<float>*>(m_collections[branch + "_dNdx"]);
+    auto* pathLengthCollection = static_cast<podio::UserDataCollection<float>*>(m_collections[branch + "_L"]);
 
     auto* mcRecoRelations =
         static_cast<edm4hep::MCRecoParticleAssociationCollection*>(m_collections[m_mcRecoAssocCollName]);

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -160,7 +160,7 @@ namespace k4SimDelphes {
     m_recoParticleGenIds.clear();
   }
 
-  void DelphesEDM4HepConverter::processParticles(const TClonesArray* delphesCollection, std::string_view const branch) {
+  void DelphesEDM4HepConverter::processParticles(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* collection = static_cast<edm4hep::MCParticleCollection*>(m_collections[branch]);
     for (int iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<GenParticle*>(delphesCollection->At(iCand));
@@ -189,7 +189,7 @@ namespace k4SimDelphes {
     }
   }
 
-  void DelphesEDM4HepConverter::processTracks(const TClonesArray* delphesCollection, std::string_view const branch) {
+  void DelphesEDM4HepConverter::processTracks(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* particleCollection = static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[m_recoCollName]);
     auto* trackCollection    = static_cast<edm4hep::TrackCollection*>(m_collections[branch]);
     //UserData for overflowing information
@@ -251,7 +251,7 @@ namespace k4SimDelphes {
     }
   }
 
-  void DelphesEDM4HepConverter::processClusters(const TClonesArray* delphesCollection, std::string_view const branch) {
+  void DelphesEDM4HepConverter::processClusters(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* particleCollection = static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[m_recoCollName]);
     auto* clusterCollection  = static_cast<edm4hep::ClusterCollection*>(m_collections[branch]);
     auto* mcRecoRelations =
@@ -296,7 +296,7 @@ namespace k4SimDelphes {
     }
   }
 
-  void DelphesEDM4HepConverter::processJets(const TClonesArray* delphesCollection, std::string_view const branch) {
+  void DelphesEDM4HepConverter::processJets(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* jetCollection = static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[branch]);
     auto* idCollection  = static_cast<edm4hep::ParticleIDCollection*>(m_collections[m_particleIDName]);
 
@@ -332,8 +332,8 @@ namespace k4SimDelphes {
   }
 
   template <typename DelphesT>
-  void DelphesEDM4HepConverter::fillReferenceCollection(const TClonesArray*    delphesCollection,
-                                                        std::string_view const branch, std::string_view const type) {
+  void DelphesEDM4HepConverter::fillReferenceCollection(const TClonesArray* delphesCollection,
+                                                        std::string const& branch, std::string_view const type) {
     auto* collection = static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[branch]);
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
@@ -359,7 +359,7 @@ namespace k4SimDelphes {
     }
   }
 
-  void DelphesEDM4HepConverter::processMissingET(const TClonesArray* delphesCollection, std::string_view const branch) {
+  void DelphesEDM4HepConverter::processMissingET(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* collection  = static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[branch]);
     auto* delphesCand = static_cast<MissingET*>(delphesCollection->At(0));
 
@@ -370,7 +370,7 @@ namespace k4SimDelphes {
     // cand.setMass(delphesCand->Mass);
   }
 
-  void DelphesEDM4HepConverter::processScalarHT(const TClonesArray* delphesCollection, std::string_view const branch) {
+  void DelphesEDM4HepConverter::processScalarHT(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* collection  = static_cast<edm4hep::ParticleIDCollection*>(m_collections[branch]);
     auto* delphesCand = static_cast<ScalarHT*>(delphesCollection->At(0));
 

--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -55,12 +55,6 @@ template <typename WriterT = podio::ROOTWriter> int doit(int argc, char* argv[],
       podioWriter.registerForWrite(std::string(c.first));
     }
 
-    auto userdatacollections = edm4hepConverter.getUserDataCollections();
-    for (auto& c : userdatacollections) {
-      eventStore.registerCollection(std::string(c.first), c.second);
-      podioWriter.registerForWrite(std::string(c.first));
-    }
-
     // has to happen before InitTask
     TObjArray* allParticleOutputArray    = modularDelphes->ExportArray("allParticles");
     TObjArray* stableParticleOutputArray = modularDelphes->ExportArray("stableParticles");


### PR DESCRIPTION
BEGINRELEASENOTES
- Store `podio::UserDataCollection` in the same map as other collections internally, so that all collections can be stored through the same interface.
  - By doing so making the new outputs also available to the framework use case.
- Switch the internal collection map from using `std::string_view` keys to `std::string` keys to make it easier to define collection names that are derived from Delphes branch names.

ENDRELEASENOTES
