### PR TITLE
Introduce podio::Frame

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -112,7 +112,15 @@ namespace k4SimDelphes {
 
     void registerGlobalCollections();
 
+    /** Create a collection in the internal map
+     */
     template <typename CollectionT> CollectionT* createCollection(std::string const& name, bool makeRefColl = false);
+
+    /** Get a collection that has already been registered in the internal map
+     */
+    template <typename CollectionT> CollectionT* getCollection(const std::string& name) {
+      return static_cast<CollectionT*>(m_collections[name].get());
+    }
 
     // cannot mark DelphesT as const, because for Candidate* the GetCandidates()
     // method is not marked as const.

--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -73,6 +73,9 @@ namespace k4SimDelphes {
     DelphesEDM4HepConverter(const std::vector<BranchSettings>& branches, OutputSettings const& outputSettings,
                             double magFieldBz);
 
+    /**
+     * Process the passed delphesTree and convert the particles contained in it.
+     */
     void process(TTree* delphesTree);
 
     /** Get the converted collections and their ownership.

--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -83,6 +83,10 @@ namespace k4SimDelphes {
      */
     CollectionMapT getCollections() { return std::move(m_collections); }
 
+    edm4hep::MCRecoParticleAssociationCollection* createExternalRecoAssociations(
+        const std::unordered_map<UInt_t, edm4hep::MCParticle>& mc_map);
+
+  private:
     void processParticles(const TClonesArray* delphesCollection, std::string const& branch);
     void processTracks(const TClonesArray* delphesCollection, std::string const& branch);
     void processClusters(const TClonesArray* delphesCollection, std::string const& branch);
@@ -100,9 +104,6 @@ namespace k4SimDelphes {
     void processElectrons(const TClonesArray* delphesCollection, std::string const& branch) {
       fillReferenceCollection<Electron>(delphesCollection, branch, "electron");
     }
-
-    edm4hep::MCRecoParticleAssociationCollection* createExternalRecoAssociations(
-        const std::unordered_map<UInt_t, edm4hep::MCParticle>& mc_map);
 
   private:
     template <typename DelphesT>

--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -17,6 +17,7 @@
 #include "modules/Delphes.h"
 
 #include <array>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -65,6 +66,8 @@ namespace k4SimDelphes {
 
   class DelphesEDM4HepConverter {
   public:
+    using CollectionMapT = std::unordered_map<std::string, std::unique_ptr<podio::CollectionBase>>;
+
     DelphesEDM4HepConverter(std::string filename_delphescard);
 
     DelphesEDM4HepConverter(const std::vector<BranchSettings>& branches, OutputSettings const& outputSettings,
@@ -72,7 +75,13 @@ namespace k4SimDelphes {
 
     void process(TTree* delphesTree);
 
-    inline const std::unordered_map<std::string, podio::CollectionBase*>& getCollections() { return m_collections; }
+    /** Get the converted collections and their ownership.
+     *
+     * NOTE: Since this moves the ownership of the internal collections, this
+     * can only be called once to actually get a filled map, after a call to
+     * process.
+     */
+    CollectionMapT getCollections() { return std::move(m_collections); }
 
     void processParticles(const TClonesArray* delphesCollection, std::string const& branch);
     void processTracks(const TClonesArray* delphesCollection, std::string const& branch);
@@ -102,7 +111,7 @@ namespace k4SimDelphes {
 
     void registerGlobalCollections();
 
-    template <typename CollectionT> void createCollection(std::string const& name, bool makeRefColl = false);
+    template <typename CollectionT> CollectionT* createCollection(std::string const& name, bool makeRefColl = false);
 
     // cannot mark DelphesT as const, because for Candidate* the GetCandidates()
     // method is not marked as const.
@@ -111,9 +120,9 @@ namespace k4SimDelphes {
 
     using ProcessFunction = void (DelphesEDM4HepConverter::*)(const TClonesArray*, std::string const&);
 
-    std::vector<BranchSettings>                             m_branches;
-    std::unordered_map<std::string, podio::CollectionBase*> m_collections;
-    std::unordered_map<std::string_view, ProcessFunction>   m_processFunctions;
+    std::vector<BranchSettings>                           m_branches;
+    CollectionMapT                                        m_collections;
+    std::unordered_map<std::string_view, ProcessFunction> m_processFunctions;
 
     double m_magneticFieldBz;  // necessary for determining track parameters
 
@@ -129,10 +138,17 @@ namespace k4SimDelphes {
   };
 
   template <typename CollectionT>
-  void DelphesEDM4HepConverter::createCollection(std::string const& name, bool makeRefColl) {
-    CollectionT* col = new CollectionT();
+  CollectionT* DelphesEDM4HepConverter::createCollection(std::string const& name, bool makeRefColl) {
+    auto col = std::make_unique<CollectionT>();
     col->setSubsetCollection(makeRefColl);
-    m_collections.emplace(name, col);
+    auto [it, inserted] = m_collections.emplace(name, std::move(col));
+    if (!inserted) {
+      std::cerr << "K4SIMDELPHES ERROR: Collection with name " << name
+                << " already created. Cannot have a second collection with this name!" << std::endl;
+      // TODO: Something more drastic?
+    }
+
+    return static_cast<CollectionT*>(it->second.get());
   }
 
 }  //namespace k4SimDelphes

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -181,16 +181,14 @@ namespace k4SimDelphes {
   }
 
   void DelphesEDM4HepConverter::processTracks(const TClonesArray* delphesCollection, std::string const& branch) {
-    auto* particleCollection =
-        static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[m_recoCollName].get());
-    auto* trackCollection = createCollection<edm4hep::TrackCollection>(branch);
+    auto* particleCollection = getCollection<edm4hep::ReconstructedParticleCollection>(m_recoCollName);
+    auto* trackCollection    = createCollection<edm4hep::TrackCollection>(branch);
     //UserData for overflowing information
     auto* pathLengthCollection = createCollection<podio::UserDataCollection<float>>(branch + "_L");
 
-    auto* mcRecoRelations =
-        static_cast<edm4hep::MCRecoParticleAssociationCollection*>(m_collections[m_mcRecoAssocCollName].get());
-    auto* idCollection   = static_cast<edm4hep::ParticleIDCollection*>(m_collections[m_particleIDName].get());
-    auto* trackerHitColl = static_cast<edm4hep::TrackerHitCollection*>(m_collections[TRACKERHIT_OUTPUT_NAME].get());
+    auto* mcRecoRelations = getCollection<edm4hep::MCRecoParticleAssociationCollection>(m_mcRecoAssocCollName);
+    auto* idCollection    = getCollection<edm4hep::ParticleIDCollection>(m_particleIDName);
+    auto* trackerHitColl  = getCollection<edm4hep::TrackerHitCollection>(TRACKERHIT_OUTPUT_NAME);
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Track*>(delphesCollection->At(iCand));
@@ -248,11 +246,9 @@ namespace k4SimDelphes {
   }
 
   void DelphesEDM4HepConverter::processClusters(const TClonesArray* delphesCollection, std::string const& branch) {
-    auto* particleCollection =
-        static_cast<edm4hep::ReconstructedParticleCollection*>(m_collections[m_recoCollName].get());
-    auto* clusterCollection = createCollection<edm4hep::ClusterCollection>(branch);
-    auto* mcRecoRelations =
-        static_cast<edm4hep::MCRecoParticleAssociationCollection*>(m_collections[m_mcRecoAssocCollName].get());
+    auto* particleCollection = getCollection<edm4hep::ReconstructedParticleCollection>(m_recoCollName);
+    auto* clusterCollection  = createCollection<edm4hep::ClusterCollection>(branch);
+    auto* mcRecoRelations    = getCollection<edm4hep::MCRecoParticleAssociationCollection>(m_mcRecoAssocCollName);
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Tower*>(delphesCollection->At(iCand));
@@ -295,7 +291,7 @@ namespace k4SimDelphes {
 
   void DelphesEDM4HepConverter::processJets(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* jetCollection = createCollection<edm4hep::ReconstructedParticleCollection>(branch);
-    auto* idCollection  = static_cast<edm4hep::ParticleIDCollection*>(m_collections[m_particleIDName].get());
+    auto* idCollection  = getCollection<edm4hep::ParticleIDCollection>(m_particleIDName);
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Jet*>(delphesCollection->At(iCand));

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -17,10 +17,10 @@ k4SimDelphesAlg::k4SimDelphesAlg(const std::string& name, ISvcLocator* svcLoc)
 
 StatusCode k4SimDelphesAlg::initialize() {
   ///-- setup Configuration and input arrays //////////////////////////////////
-  m_Delphes       = std::make_unique<Delphes>("Delphes");
-  auto confReader = ExRootConfReader();
-  confReader.ReadFile(m_DelphesCard.value().c_str());
-  m_Delphes->SetConfReader(&confReader);
+  m_Delphes    = std::make_unique<Delphes>("Delphes");
+  m_confReader = std::make_unique<ExRootConfReader>();
+  m_confReader->ReadFile(m_DelphesCard.value().c_str());
+  m_Delphes->SetConfReader(m_confReader.get());
   m_treeWriter    = new ExRootTreeWriter(nullptr, "Delphes");
   m_converterTree = new TTree("ConverterTree", "Analysis");
   // avoid having any connection with a TFile that might be opened later
@@ -38,10 +38,10 @@ StatusCode k4SimDelphesAlg::initialize() {
   m_eventDataSvc.retrieve().ignore();
   m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
-  const auto branches       = getBranchSettings(confReader.GetParam("TreeWriter::Branch"));
+  const auto branches       = getBranchSettings(m_confReader->GetParam("TreeWriter::Branch"));
   const auto outputSettings = getEDM4hepOutputSettings(m_DelphesOutputSettings.value().c_str());
   m_edm4hepConverter        = std::make_unique<k4SimDelphes::DelphesEDM4HepConverter>(
-      branches, outputSettings, confReader.GetDouble("ParticlePropagator::Bz", 0));
+      branches, outputSettings, m_confReader->GetDouble("ParticlePropagator::Bz", 0));
 
   return StatusCode::SUCCESS;
 }

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -76,7 +76,7 @@ StatusCode k4SimDelphesAlg::execute() {
     }
 
     DataWrapper<podio::CollectionBase>* wrapper = new DataWrapper<podio::CollectionBase>();
-    wrapper->setData(c.second);
+    wrapper->setData(c.second.release());  // TODO: Does DataWrapper take ownership?
     m_podioDataSvc->registerObject("/Event", "/" + std::string(c.first), wrapper).ignore();
   }
   m_Delphes->Clear();

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -79,7 +79,7 @@ StatusCode k4SimDelphesAlg::execute() {
     }
 
     DataWrapper<podio::CollectionBase>* wrapper = new DataWrapper<podio::CollectionBase>();
-    wrapper->setData(c.second.release());  // TODO: Does DataWrapper take ownership?
+    wrapper->setData(c.second.release());  // DataWrapper takes ownership
     m_podioDataSvc->registerObject("/Event", "/" + std::string(c.first), wrapper).ignore();
   }
   m_Delphes->Clear();

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.h
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.h
@@ -49,6 +49,7 @@ private:
       this, "DelphesOutputSettings", "", "Name of config file with k4simdelphes specific output settings"};
 
   std::unique_ptr<Delphes>                               m_Delphes{nullptr};
+  std::unique_ptr<ExRootConfReader>                      m_confReader{nullptr};
   std::unique_ptr<k4SimDelphes::DelphesEDM4HepConverter> m_edm4hepConverter{nullptr};
   TObjArray*                                             m_allParticleOutputArray{nullptr};
   TObjArray*                                             m_stableParticleOutputArray{nullptr};

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.h
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.h
@@ -1,18 +1,21 @@
 #ifndef _K4SIMDELPHESALG_H
 #define _K4SIMDELPHESALG_H
 
-#include "GaudiAlg/GaudiAlgorithm.h"
-#include "k4FWCore/DataHandle.h"
-#include "k4FWCore/DataWrapper.h"
-#include "k4FWCore/PodioDataSvc.h"
+#include "k4SimDelphes/DelphesEDM4HepConverter.h"
+#include "k4SimDelphes/DelphesEDM4HepOutputConfiguration.h"
 
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/ReconstructedParticleCollection.h"
 
-#include "k4SimDelphes/DelphesEDM4HepConverter.h"
-#include "k4SimDelphes/DelphesEDM4HepOutputConfiguration.h"
+#include "k4FWCore/DataHandle.h"
+#include "k4FWCore/DataWrapper.h"
+#include "k4FWCore/PodioDataSvc.h"
+
+#include "GaudiAlg/GaudiAlgorithm.h"
 
 #include "modules/Delphes.h"
+
+#include <memory>
 
 namespace edm4hep {
   class MCParticleCollection;
@@ -45,23 +48,20 @@ private:
   Gaudi::Property<std::string> m_DelphesOutputSettings{
       this, "DelphesOutputSettings", "", "Name of config file with k4simdelphes specific output settings"};
 
-  std::unique_ptr<Delphes> m_Delphes{nullptr};
-  //std::unique_ptr<k4SimDelphes::DelphesEDM4HepConverter> m_edm4hepConverter{nullptr};
-  k4SimDelphes::DelphesEDM4HepConverter* m_edm4hepConverter{nullptr};
-  TObjArray*                             m_allParticleOutputArray{nullptr};
-  TObjArray*                             m_stableParticleOutputArray{nullptr};
-  TObjArray*                             m_partonOutputArray{nullptr};
+  std::unique_ptr<Delphes>                               m_Delphes{nullptr};
+  std::unique_ptr<k4SimDelphes::DelphesEDM4HepConverter> m_edm4hepConverter{nullptr};
+  TObjArray*                                             m_allParticleOutputArray{nullptr};
+  TObjArray*                                             m_stableParticleOutputArray{nullptr};
+  TObjArray*                                             m_partonOutputArray{nullptr};
 
   ExRootTreeWriter* m_treeWriter{nullptr};
   TTree*            m_converterTree{nullptr};
-  ExRootConfReader* m_confReader{nullptr};
 
   // since branch names are taken from delphes config
   // and not declared as data handles,
   // need podiodatasvc directly
   PodioDataSvc*                   m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
-  k4SimDelphes::OutputSettings    m_edm4hepOutputSettings;
 };
 
 #endif  // _K4SIMDELPHESALG_H

--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -72,15 +72,8 @@ template <typename WriterT = podio::ROOTFrameWriter> int doit(int argc, char* ar
       podio::Frame frame;
       for (auto& [name, coll] : edm4hepConverter.getCollections()) {
         frame.put(std::move(coll), name);
-
-        // The first time around we have to register the collections
-        // TODO: Fix upstream in podio to use a better default
-        if (entry == 0) {
-          podioWriter.registerForWrite(name);
-        }
       }
-
-      podioWriter.writeFrame(frame);
+      podioWriter.writeFrame(frame, "events");
 
       modularDelphes->Clear();
       progressBar.Update(eventCounter, eventCounter);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ function(ADD_COMPARISON_TEST name converter)
     COMMAND bash -x ${CMAKE_SOURCE_DIR}/tests/testDriver.sh ${converter} ${ARGN})
 
   set_property(TEST ${name} PROPERTY ENVIRONMENT
-    LD_LIBRARY_PATH=$<TARGET_FILE_DIR:DelphesEDM4HepConverter>:$<TARGET_FILE_DIR:EDM4HEP::edm4hepDict>:$<TARGET_FILE_DIR:podio::podioDict>:$ENV{LD_LIBRARY_PATH}
+    LD_LIBRARY_PATH=$<TARGET_FILE_DIR:DelphesEDM4HepConverter>:$<TARGET_FILE_DIR:EDM4HEP::edm4hepDict>:$<TARGET_FILE_DIR:podio::podioDict>:$<TARGET_FILE_DIR:ROOT::RIO>:$ENV{LD_LIBRARY_PATH}
     PATH=$<TARGET_FILE_DIR:${converter}>:${DELPHES_BINARY_DIR}:$ENV{PATH}
     COMPARE=$<TARGET_FILE:compare_delphes_converter_outputs>
     )


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the standalone executables use the `podio::Frame`

ENDRELEASENOTES

I have this compiling and running successfully locally, but the CI is obviously not using a bunch of unmerged PRs from podio, so for the moment this is mainly showcasing the usage of the `podio::Frame` in a real world example.

- [x] Needs AIDASoft/podio#287 (and in general the [Frame](https://github.com/AIDASoft/podio/projects/1)
- [x] Also contains all changes from #84