### PR TITLE
Fix segmentation fault when passing no arguments

### DIFF
--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -26,7 +26,7 @@ template <typename WriterT = podio::ROOTWriter> int doit(int argc, char* argv[],
   if (outputFile.empty()) {
     // Check if the user requested the help, and print the usage message and
     // return succesfully in that case
-    if (argv[1] == std::string_view("--help") || argv[1] == std::string_view("-h")) {
+    if (argc > 1 && (argv[1] == std::string_view("--help") || argv[1] == std::string_view("-h"))) {
       std::cout << inputReader.getUsage() << std::endl;
       return 0;
     }


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix segmentation fault when passing no arguments to standalone executables by explicitly checking whether arguments are passed

ENDRELEASENOTES

The check introduced in #72 is faulty if there are no arguments passed to the executable and there is a segfault.