### PR TITLE
Add more cluster, track and gen particle information

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -45,6 +45,12 @@ namespace k4SimDelphes {
    * Classes that will be stored as TrackerHits
    */
   constexpr auto TRACKERHIT_OUTPUT_NAME = "TrackerHits";
+  
+  /**
+   * * Classes that will be stored as TrackerHits
+   */
+  constexpr auto CALORIMETERHIT_OUTPUT_NAME = "CalorimeterHits";
+
 
   struct BranchSettings {
     std::string input;

--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -45,12 +45,11 @@ namespace k4SimDelphes {
    * Classes that will be stored as TrackerHits
    */
   constexpr auto TRACKERHIT_OUTPUT_NAME = "TrackerHits";
-  
+
   /**
    * * Classes that will be stored as TrackerHits
    */
   constexpr auto CALORIMETERHIT_OUTPUT_NAME = "CalorimeterHits";
-
 
   struct BranchSettings {
     std::string input;

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -269,11 +269,15 @@ namespace k4SimDelphes {
       // that would probably make the matching that is done below much harder
 
       auto       cand     = particleCollection->create();
-      const auto momentum = delphesCand->P4();  // NOTE: assuming massless here!
+      // NOTE: Delphes assumes m=0 for photons and m=0.497611 for neutral hadrons (KL)
+      const auto momentum = delphesCand->P4();  
       // TODO: fill this when it is available later, when when we link the references?
       // cand.setCharge(delphesCand->Charge);
       cand.setMomentum({(float)momentum.Px(), (float)momentum.Py(), (float)momentum.Pz()});
       cand.setEnergy(delphesCand->E);
+      cand.setMass(delphesCand->P4().M());
+      auto pid = (delphesCand->Ehad > 0.) ? 130 : 22;
+      cand.setType(pid); // NOTE: set PID of cluster consistent with mass
 
       cand.addToClusters(cluster);
 

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -162,6 +162,7 @@ namespace k4SimDelphes {
       cand.setMass(delphesCand->Mass);
       cand.setMomentum({delphesCand->Px, delphesCand->Py, delphesCand->Pz});
       cand.setVertex({delphesCand->X, delphesCand->Y, delphesCand->Z});
+      cand.setTime(delphesCand->T); // in seconds
       cand.setPDG(delphesCand->PID);  // delphes uses whatever hepevt.idhep provides
       cand.setGeneratorStatus(delphesCand->Status);
 
@@ -195,10 +196,10 @@ namespace k4SimDelphes {
       auto* delphesCand = static_cast<Track*>(delphesCollection->At(iCand));
 
       auto track       = convertTrack(delphesCand, m_magneticFieldBz);
-       
+
       // this is the position/time at the IP
       auto trackerHit0 = trackerHitColl->create();
-      trackerHit0.setTime(delphesCand->T);
+      trackerHit0.setTime(delphesCand->T); // in seconds
       edm4hep::Vector3d position0(delphesCand->X, delphesCand->Y, delphesCand->Z);
       trackerHit0.setPosition(position0);
       track.addToTrackerHits(trackerHit0);
@@ -209,9 +210,9 @@ namespace k4SimDelphes {
       trackerHit1.setPosition(position1);
       track.addToTrackerHits(trackerHit1);
 
-      // this is the position/time at the calorimeter 
+      // this is the position/time at the calorimeter
       auto trackerHit2 = trackerHitColl->create();
-      trackerHit2.setTime(delphesCand->TOuter);
+      trackerHit2.setTime(delphesCand->TOuter);  // in seconds
       edm4hep::Vector3d position2(delphesCand->XOuter, delphesCand->YOuter, delphesCand->ZOuter);
       trackerHit2.setPosition(position2);
       track.addToTrackerHits(trackerHit2);
@@ -260,7 +261,7 @@ namespace k4SimDelphes {
     auto* clusterCollection  = createCollection<edm4hep::ClusterCollection>(branch);
     auto* mcRecoRelations    = getCollection<edm4hep::MCRecoParticleAssociationCollection>(m_mcRecoAssocCollName);
     auto* calorimeterHitColl  = getCollection<edm4hep::CalorimeterHitCollection>(CALORIMETERHIT_OUTPUT_NAME);
-    
+
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Tower*>(delphesCollection->At(iCand));
 
@@ -281,7 +282,7 @@ namespace k4SimDelphes {
 
       auto       cand     = particleCollection->create();
       // NOTE: Delphes assumes m=0 for photons and m=0.497611 for neutral hadrons (KL)
-      const auto momentum = delphesCand->P4();  
+      const auto momentum = delphesCand->P4();
       // TODO: fill this when it is available later, when when we link the references?
       // cand.setCharge(delphesCand->Charge);
       cand.setMomentum({(float)momentum.Px(), (float)momentum.Py(), (float)momentum.Pz()});
@@ -293,7 +294,7 @@ namespace k4SimDelphes {
 
       // store position and time of neutral candidate in a CalorimeterHit
       auto calorimeterHit = calorimeterHitColl->create();
-      calorimeterHit.setTime(delphesCand->T);
+      calorimeterHit.setTime(delphesCand->T); // in seconds
       edm4hep::Vector3f position(delphesCand->X, delphesCand->Y, delphesCand->Z);
       calorimeterHit.setPosition(position);
       cluster.addToHits(calorimeterHit);

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -2,6 +2,7 @@
 #include "delphesHelpers.h"  // getAllParticleIds
 #include "k4SimDelphes/DelphesEDM4HepOutputConfiguration.h"
 
+#include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/MCRecoParticleAssociationCollection.h"
@@ -9,7 +10,6 @@
 #include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHitCollection.h"
-#include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/Vector3d.h"
 
 #include "podio/UserDataCollection.h"
@@ -163,7 +163,7 @@ namespace k4SimDelphes {
       cand.setMass(delphesCand->Mass);
       cand.setMomentum({delphesCand->Px, delphesCand->Py, delphesCand->Pz});
       cand.setVertex({delphesCand->X, delphesCand->Y, delphesCand->Z});
-      cand.setTime(delphesCand->T); // in seconds
+      cand.setTime(delphesCand->T);   // in seconds
       cand.setPDG(delphesCand->PID);  // delphes uses whatever hepevt.idhep provides
       cand.setGeneratorStatus(delphesCand->Status);
 
@@ -196,17 +196,17 @@ namespace k4SimDelphes {
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Track*>(delphesCollection->At(iCand));
 
-      auto track       = convertTrack(delphesCand, m_magneticFieldBz);
+      auto track = convertTrack(delphesCand, m_magneticFieldBz);
 
       // this is the position/time at the IP
       auto trackerHit0 = trackerHitColl->create();
-      trackerHit0.setTime(delphesCand->T); // in seconds
+      trackerHit0.setTime(delphesCand->T);  // in seconds
       edm4hep::Vector3d position0(delphesCand->X, delphesCand->Y, delphesCand->Z);
       trackerHit0.setPosition(position0);
       track.addToTrackerHits(trackerHit0);
 
       // this is the position of the first hit (NB: time not available in Delphes here)
-      auto trackerHit1 = trackerHitColl->create();
+      auto              trackerHit1 = trackerHitColl->create();
       edm4hep::Vector3d position1(delphesCand->XFirstHit, delphesCand->YFirstHit, delphesCand->ZFirstHit);
       trackerHit1.setPosition(position1);
       track.addToTrackerHits(trackerHit1);
@@ -262,7 +262,7 @@ namespace k4SimDelphes {
     auto* particleCollection = getCollection<edm4hep::ReconstructedParticleCollection>(m_recoCollName);
     auto* clusterCollection  = createCollection<edm4hep::ClusterCollection>(branch);
     auto* mcRecoRelations    = getCollection<edm4hep::MCRecoParticleAssociationCollection>(m_mcRecoAssocCollName);
-    auto* calorimeterHitColl  = getCollection<edm4hep::CalorimeterHitCollection>(CALORIMETERHIT_OUTPUT_NAME);
+    auto* calorimeterHitColl = getCollection<edm4hep::CalorimeterHitCollection>(CALORIMETERHIT_OUTPUT_NAME);
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Tower*>(delphesCollection->At(iCand));
@@ -282,7 +282,7 @@ namespace k4SimDelphes {
       // edm4hep::clusters, with energies split according to Eem and Ehad. But
       // that would probably make the matching that is done below much harder
 
-      auto       cand     = particleCollection->create();
+      auto cand = particleCollection->create();
       // NOTE: Delphes assumes m=0 for photons and m=0.497611 for neutral hadrons (KL)
       const auto momentum = delphesCand->P4();
       // TODO: fill this when it is available later, when when we link the references?
@@ -292,11 +292,11 @@ namespace k4SimDelphes {
       cand.setMass(delphesCand->P4().M());
       // NOTE: Particle-Flow Neutral are either photons or K_L in Delphes
       auto pid = (delphesCand->Ehad > 0.) ? 130 : 22;
-      cand.setType(pid); // NOTE: set PID of cluster consistent with mass
+      cand.setType(pid);  // NOTE: set PID of cluster consistent with mass
 
       // store position and time of neutral candidate in a CalorimeterHit
       auto calorimeterHit = calorimeterHitColl->create();
-      calorimeterHit.setTime(delphesCand->T); // in seconds
+      calorimeterHit.setTime(delphesCand->T);  // in seconds
       edm4hep::Vector3f position(delphesCand->X, delphesCand->Y, delphesCand->Z);
       calorimeterHit.setPosition(position);
       cluster.addToHits(calorimeterHit);

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -195,12 +195,21 @@ namespace k4SimDelphes {
       auto* delphesCand = static_cast<Track*>(delphesCollection->At(iCand));
 
       auto track       = convertTrack(delphesCand, m_magneticFieldBz);
+       
+      // this is the position/time at the IP
+      auto trackerHit0 = trackerHitColl->create();
+      trackerHit0.setTime(delphesCand->T);
+      edm4hep::Vector3d position0(delphesCand->X, delphesCand->Y, delphesCand->Z);
+      trackerHit0.setPosition(position0);
+      track.addToTrackerHits(trackerHit0);
+
+      // this is the position of the first hit (NB: time not available in Delphes here)
       auto trackerHit1 = trackerHitColl->create();
-      trackerHit1.setTime(delphesCand->T);
       edm4hep::Vector3d position1(delphesCand->XFirstHit, delphesCand->YFirstHit, delphesCand->ZFirstHit);
       trackerHit1.setPosition(position1);
       track.addToTrackerHits(trackerHit1);
 
+      // this is the position/time at the calorimeter 
       auto trackerHit2 = trackerHitColl->create();
       trackerHit2.setTime(delphesCand->TOuter);
       edm4hep::Vector3d position2(delphesCand->XOuter, delphesCand->YOuter, delphesCand->ZOuter);


### PR DESCRIPTION
BEGINRELEASENOTES
- set mass to KL or Photon for neutral clusters respectively
- store position and time of cluster via calorimeterHit
- set first track hit as MC truth track vertex
- added vertex time to MC truth particle

ENDRELEASENOTES
