### PR TITLE
Fix occasional warnings from missing jet constituents

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -145,8 +145,14 @@ namespace k4SimDelphes {
     // map from UniqueIDs (delphes generated particles) to MCParticles
     std::unordered_map<UInt_t, edm4hep::MCParticle> m_genParticleIds;
     // map from UniqueIDs (delphes generated particles) to (possibly multiple)
-    // ReconstructedParticles
+    // ReconstructedParticles. This map is necessary because Muon, Electron and
+    // Photon can only be reliably matched via their gen particles
     std::unordered_multimap<UInt_t, edm4hep::MutableReconstructedParticle> m_recoParticleGenIds;
+    // Map of UniqueIDs (delphes candidates) to ReconstrucedParticles. Used in
+    // putting together the list of jet constituents. This is necessary because
+    // the particle flow implementation of Delphes creates candidates without a
+    // gen particle.
+    std::unordered_map<UInt_t, edm4hep::MutableReconstructedParticle> m_recoParticleIds;
   };
 
   template <typename CollectionT>

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -148,6 +148,7 @@ namespace k4SimDelphes {
     // into maps here for internal use only (see #89)
     m_genParticleIds.clear();
     m_recoParticleGenIds.clear();
+    m_recoParticleIds.clear();
   }
 
   void DelphesEDM4HepConverter::processParticles(const TClonesArray* delphesCollection, std::string const& branch) {
@@ -242,6 +243,7 @@ namespace k4SimDelphes {
       }
 
       m_recoParticleGenIds.emplace(genId, cand);
+      m_recoParticleIds.emplace(delphesCand->GetUniqueID(), cand);
     }
   }
 
@@ -286,6 +288,7 @@ namespace k4SimDelphes {
 
         m_recoParticleGenIds.emplace(genId, cand);
       }
+      m_recoParticleIds.emplace(delphesCand->GetUniqueID(), cand);
     }
   }
 
@@ -313,10 +316,9 @@ namespace k4SimDelphes {
 
       const auto& constituents = delphesCand->Constituents;
       for (auto iConst = 0; iConst < constituents.GetEntries(); ++iConst) {
-        // TODO: Can we do better than Candidate here?
         auto* constituent = static_cast<Candidate*>(constituents.At(iConst));
-        if (auto matchedReco = getMatchingReco(constituent)) {
-          jet.addToParticles(*matchedReco);
+        if (const auto it = m_recoParticleIds.find(constituent->GetUniqueID()); it != m_recoParticleIds.end()) {
+          jet.addToParticles(it->second);
         } else {
           std::cerr << "**** WARNING: No matching ReconstructedParticle was found for a Jet constituent" << std::endl;
         }


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the long(er) standing issue of having jet constituents without matching reconstructed particle.

ENDRELEASENOTES

The underlying reason for this is that delphes sometimes creates candidates without a gen particle, which is used for the matching of Muon, Electron and Photon. By using the UniqueID of the jet constituents directly we don't need to go back to the gen particles, but can directly match on the reconstructed particles.

@selvaggi, can you briefly verify that the logic I implemented here with the additional map, is actually what we discussed some time back?
