### PR TITLE
Make it possible to turn off conversion of some collections

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepOutputConfiguration.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepOutputConfiguration.h
@@ -140,20 +140,17 @@ namespace k4SimDelphes {
     settings.GenParticleCollections =
         toVecString(confReader->GetParam("EDM4HepOutput::GenParticleCollections"), {"GenParticle"});
 
-    settings.JetCollections = toVecString(confReader->GetParam("EDM4HepOutput::JetCollections"), {"Jet"});
+    settings.JetCollections = toVecString(confReader->GetParam("EDM4HepOutput::JetCollections"), {});
 
-    settings.MuonCollections = toVecString(confReader->GetParam("EDM4HepOutput::MuonCollections"), {"Muon"});
+    settings.MuonCollections = toVecString(confReader->GetParam("EDM4HepOutput::MuonCollections"), {});
 
-    settings.ElectronCollections =
-        toVecString(confReader->GetParam("EDM4HepOutput::ElectronCollections"), {"Electron"});
+    settings.ElectronCollections = toVecString(confReader->GetParam("EDM4HepOutput::ElectronCollections"), {});
 
-    settings.PhotonCollections = toVecString(confReader->GetParam("EDM4HepOutput::PhotonCollections"), {"Photon"});
+    settings.PhotonCollections = toVecString(confReader->GetParam("EDM4HepOutput::PhotonCollections"), {});
 
-    settings.MissingETCollections =
-        toVecString(confReader->GetParam("EDM4HepOutput::MissingETCollections"), {"MissingET"});
+    settings.MissingETCollections = toVecString(confReader->GetParam("EDM4HepOutput::MissingETCollections"), {});
 
-    settings.ScalarHTCollections =
-        toVecString(confReader->GetParam("EDM4HepOutput::ScalarHTCollections"), {"ScalarHT"});
+    settings.ScalarHTCollections = toVecString(confReader->GetParam("EDM4HepOutput::ScalarHTCollections"), {});
 
     settings.RecoParticleCollectionName =
         confReader->GetString("EDM4HepOutput::RecoParticleCollectionName", "ReconstructedParticles");


### PR DESCRIPTION
BEGINRELEASENOTES
- Adapt the default values of the output configuration parameters, such that it is possible to remove some output configuration parameters from the config file to skip conversions of certain collections. Fixes #100 

ENDRELEASENOTES
