### PR TITLE
Rename `CMAKE_BINARY_DIR` to `PROJECT_BINARY_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,8 @@ endif()
 
 #--- add version files ---------------------------------------------------------
 configure_file(${PROJECT_SOURCE_DIR}/k4SimDelphesVersion.h
-               ${CMAKE_BINARY_DIR}/k4SimDelphesVersion.h )
-install(FILES ${CMAKE_BINARY_DIR}/k4SimDelphesVersion.h
+               ${PROJECT_BINARY_DIR}/k4SimDelphesVersion.h )
+install(FILES ${PROJECT_BINARY_DIR}/k4SimDelphesVersion.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/k4SimDelphes )
 
 

--- a/cmake/k4SimDelphesUninstall.cmake
+++ b/cmake/k4SimDelphesUninstall.cmake
@@ -33,14 +33,14 @@
 if (NOT TARGET uninstall)
     configure_file(
       "${CMAKE_CURRENT_LIST_DIR}/k4SimDelphes_uninstall.cmake.in"
-      "${CMAKE_BINARY_DIR}/k4SimDelphes_uninstall.cmake"
+      "${PROJECT_BINARY_DIR}/k4SimDelphes_uninstall.cmake"
         IMMEDIATE
         @ONLY
     )
 
     add_custom_target(uninstall
-      COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_BINARY_DIR}/k4SimDelphes_uninstall.cmake"
-      WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+      COMMAND "${CMAKE_COMMAND}" -P "${PROJECT_BINARY_DIR}/k4SimDelphes_uninstall.cmake"
+      WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
     )
 endif()
 

--- a/cmake/k4SimDelphes_uninstall.cmake.in
+++ b/cmake/k4SimDelphes_uninstall.cmake.in
@@ -1,8 +1,8 @@
-if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
-    message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+if(NOT EXISTS "@PROJECT_BINARY_DIR@/install_manifest.txt")
+    message(FATAL_ERROR "Cannot find install manifest: @PROJECT_BINARY_DIR@/install_manifest.txt")
 endif()
 
-file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+file(READ "@PROJECT_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
     message(STATUS "Uninstalling $ENV{DESTDIR}${file}")

--- a/framework/k4SimDelphes/CMakeLists.txt
+++ b/framework/k4SimDelphes/CMakeLists.txt
@@ -31,16 +31,16 @@ if(BUILD_TESTING)
              WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/examples/options
              COMMAND  k4run k4simdelphesalg.py)
     # set up gaudi environment for tests
-    set_property(TEST k4SimDelphesAlgBasicTest APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/framework/k4SimDelphes:$<TARGET_FILE_DIR:k4Gen::k4Gen>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$ENV{LD_LIBRARY_PATH}"
-    "PYTHONPATH=$<TARGET_FILE_DIR:k4Gen::k4Gen>/../python:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:${CMAKE_BINARY_DIR}/framework/k4SimDelphes/${GAUDI_GENCONF_DIR}:$ENV{PYTHONPATH}"
+    set_property(TEST k4SimDelphesAlgBasicTest APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}:${PROJECT_BINARY_DIR}/framework/k4SimDelphes:$<TARGET_FILE_DIR:k4Gen::k4Gen>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$ENV{LD_LIBRARY_PATH}"
+    "PYTHONPATH=$<TARGET_FILE_DIR:k4Gen::k4Gen>/../python:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:${PROJECT_BINARY_DIR}/framework/k4SimDelphes/${GAUDI_GENCONF_DIR}:$ENV{PYTHONPATH}"
     )
 
     add_test(NAME k4SimDelphesAlgPythiaTest
              WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/examples/options
              COMMAND  k4run k4simdelphesalg_pythia.py)
     # set up gaudi environment for tests
-    set_property(TEST k4SimDelphesAlgPythiaTest APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/framework/k4SimDelphes:$<TARGET_FILE_DIR:k4Gen::k4Gen>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$ENV{LD_LIBRARY_PATH}"
-    "PYTHONPATH=$<TARGET_FILE_DIR:k4Gen::k4Gen>/../python:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:${CMAKE_BINARY_DIR}/framework/k4SimDelphes/${GAUDI_GENCONF_DIR}:$ENV{PYTHONPATH}"
+    set_property(TEST k4SimDelphesAlgPythiaTest APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}:${PROJECT_BINARY_DIR}/framework/k4SimDelphes:$<TARGET_FILE_DIR:k4Gen::k4Gen>:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>:$ENV{LD_LIBRARY_PATH}"
+    "PYTHONPATH=$<TARGET_FILE_DIR:k4Gen::k4Gen>/../python:$<TARGET_FILE_DIR:k4FWCore::k4FWCore>/../python:${PROJECT_BINARY_DIR}/framework/k4SimDelphes/${GAUDI_GENCONF_DIR}:$ENV{PYTHONPATH}"
     )
 
   else()


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename `CMAKE_BINARY_DIR` to `PROJECT_BINARY_DIR`

ENDRELEASENOTES

Continuation of https://github.com/key4hep/k4SimDelphes/pull/108 but now correctly changing `CMAKE_BINARY_DIR`