### PR TITLE
Make a few cmake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(k4SimDelphes)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(k4SimDelphes)
 
@@ -78,6 +78,7 @@ endif()
 #--- Non-optional Dependencies ------------------------------------------------
 find_package(Delphes REQUIRED)
 find_package(EDM4HEP REQUIRED)
+find_package(ROOT REQUIRED)
 
 #--- optional dependencies
 if(BUILD_PYTHIA_READER OR BUILD_EVTGEN_READER)

--- a/converter/CMakeLists.txt
+++ b/converter/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries(DelphesEDM4HepConverter
                         podio::podio
                         ROOT::MathCore
                         ROOT::EG
-                        ROOT::Physics)
+                        )
 
 install(DIRECTORY include/
         TYPE INCLUDE)

--- a/framework/k4SimDelphes/examples/options/k4simdelphesalg_pythia.py
+++ b/framework/k4SimDelphes/examples/options/k4simdelphesalg_pythia.py
@@ -1,5 +1,5 @@
 from Gaudi.Configuration import *
-from GaudiKernel import SystemOfUnits as units
+import os
 
 from Configurables import ApplicationMgr
 app = ApplicationMgr()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ target_include_directories(compare_delphes_converter_outputs
   ${PROJECT_SOURCE_DIR}/converter/src #for delphesHelpers
   ${PROJECT_SOURCE_DIR}/converter/include
   )
-target_link_libraries(compare_delphes_converter_outputs PRIVATE EDM4HEP::edm4hep ${DELPHES_LIBRARY} podio::podioRootIO ROOT::Physics)
+target_link_libraries(compare_delphes_converter_outputs PRIVATE EDM4HEP::edm4hep EDM4HEP::kinematics ${DELPHES_LIBRARY} podio::podioRootIO ROOT::Core ROOT::MathCore ROOT::Physics)
 
 function(ADD_COMPARISON_TEST name converter)
   # Check if we have the standalone Delphes application available for the
@@ -29,7 +29,7 @@ function(ADD_COMPARISON_TEST name converter)
     COMMAND bash -x ${PROJECT_SOURCE_DIR}/tests/testDriver.sh ${converter} ${ARGN})
 
   set_property(TEST ${name} PROPERTY ENVIRONMENT
-    LD_LIBRARY_PATH=$<TARGET_FILE_DIR:DelphesEDM4HepConverter>:$<TARGET_FILE_DIR:EDM4HEP::edm4hepDict>:$<TARGET_FILE_DIR:podio::podioDict>:$<TARGET_FILE_DIR:ROOT::RIO>:$ENV{LD_LIBRARY_PATH}
+    LD_LIBRARY_PATH=$<TARGET_FILE_DIR:DelphesEDM4HepConverter>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:podio::podio>:$<TARGET_FILE_DIR:ROOT::RIO>:$ENV{LD_LIBRARY_PATH}
     PATH=$<TARGET_FILE_DIR:${converter}>:${DELPHES_BINARY_DIR}:$ENV{PATH}
     COMPARE=$<TARGET_FILE:compare_delphes_converter_outputs>
     )


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a cmake warning by changing the minimum version to 3.5, since support for versions < 3.5 is going to be removed in the future
- Rename the podioDict or edm4hepDict targets to podio or edm4hep in generator expressions for when they will be removed
- Add ROOT libraries at link time for building k4SimDelphes together with other packages
- Fix a test because the steering file was missing an `import os` (behaviour changed after https://github.com/key4hep/k4FWCore/pull/134)

ENDRELEASENOTES