### PR TITLE
Tack track curvature directly from Delphes and don't recompute it from pT

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -47,7 +47,7 @@ namespace k4SimDelphes {
   void sortBranchesProcessingOrder(std::vector<BranchSettings>&           branches,
                                    std::array<std::string_view, N> const& processingOrder);
 
-  edm4hep::MutableTrack convertTrack(Track const* cand, const double magFieldBz);
+  edm4hep::MutableTrack convertTrack(Track const* cand);
 
   void setMotherDaughterRelations(GenParticle const* delphesCand, edm4hep::MutableMCParticle particle,
                                   edm4hep::MCParticleCollection& mcParticles);
@@ -224,7 +224,7 @@ namespace k4SimDelphes {
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Track*>(delphesCollection->At(iCand));
 
-      auto track = convertTrack(delphesCand, m_magneticFieldBz);
+      auto track = convertTrack(delphesCand);
 
       // this is the position/time at the IP
       auto trackerHit0 = trackerHitColl->create();
@@ -540,7 +540,7 @@ namespace k4SimDelphes {
     });
   }
 
-  edm4hep::MutableTrack convertTrack(Track const* cand, const double magFieldBz) {
+  edm4hep::MutableTrack convertTrack(Track const* cand) {
     edm4hep::MutableTrack track;
     // Delphes does not really provide any information that would go into the
     // track itself. But some information can be used to at least partially

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -557,23 +557,6 @@ namespace k4SimDelphes {
     // Same thing under different name in Delphes
     trackState.tanLambda = cand->CtgTheta;
 
-/*
-    // Instead of recomputing the track's omega from its pT, better take it directly
-    // from the curvature of the delphes track - see below.
-
-    // Only do omega when there is actually a magnetic field.
-    double varOmega = 0;
-    if (magFieldBz) {
-      // conversion to have omega in [1/mm]
-      constexpr double a = c_light * 1e3 * 1e-15;
-
-      trackState.omega = a * magFieldBz / cand->PT * std::copysign(1.0, cand->Charge);
-      // calculate variation using simple error propagation, assuming
-      // constant B-field -> relative error on pT is relative error on omega
-      varOmega = cand->ErrorPT * cand->ErrorPT / cand->PT / cand->PT * trackState.omega * trackState.omega;
-    }
-*/
-
     // fill the covariance matrix. There is a conversion of units
     // because the covariance matrix in delphes is with the original units
     // from Franco Bedeschi's code so meter and GeV

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -556,6 +556,11 @@ namespace k4SimDelphes {
     trackState.phi = cand->Phi;
     // Same thing under different name in Delphes
     trackState.tanLambda = cand->CtgTheta;
+
+/*
+    // Instead of recomputing the track's omega from its pT, better take it directly
+    // from the curvature of the delphes track - see below.
+
     // Only do omega when there is actually a magnetic field.
     double varOmega = 0;
     if (magFieldBz) {
@@ -567,6 +572,7 @@ namespace k4SimDelphes {
       // constant B-field -> relative error on pT is relative error on omega
       varOmega = cand->ErrorPT * cand->ErrorPT / cand->PT / cand->PT * trackState.omega * trackState.omega;
     }
+*/
 
     // fill the covariance matrix. There is a conversion of units
     // because the covariance matrix in delphes is with the original units
@@ -578,6 +584,8 @@ namespace k4SimDelphes {
     // needs to be applied to any covariance matrix element
     // relating to curvature (index 2)
     double scale2 = -2.;  // CAREFUL: DELPHES USES THE HALF-CURVATURE
+
+    trackState.omega = cand->C * scale2  ;
 
     covMatrix[0] = covaFB(0, 0);
 

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -568,7 +568,7 @@ namespace k4SimDelphes {
     // relating to curvature (index 2)
     double scale2 = -2.;  // CAREFUL: DELPHES USES THE HALF-CURVATURE
 
-    trackState.omega = cand->C * scale2  ;
+    trackState.omega = cand->C * scale2;
 
     covMatrix[0] = covaFB(0, 0);
 

--- a/converter/src/delphesHelpers.h
+++ b/converter/src/delphesHelpers.h
@@ -11,8 +11,6 @@
 #include <vector>
 
 namespace k4SimDelphes {
-  // TODO: If CLHEP ever gets part of edm4hep, take this from there.
-  static constexpr double c_light = 2.99792458e+8;
 
   using LorentzVectorT = ROOT::Math::PxPyPzEVector;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- The track's omega is taken directly from the curvature of the delphes track, instead of recomputing it from the track pT. Converting the curvature to pT and then back to omega leads to a worse numerical precision.

ENDRELEASENOTES

 An example is shown in the attached plots. They show the pull of the reconstructed position of a displaced vertex in some B physics process, running the very same code over the same events, the only difference being the  definition of the track's omega in  DelphesEDM4HepConverter::convertTrack. With the current code, the pull shows some non gaussian tails, which are absent if omega is taken directly from the curvature of Delphes.

![pull_KsVertex](https://github.com/key4hep/k4SimDelphes/assets/5372932/5cb3265b-bf88-449b-8e4e-c988d79f445f)
![pull_KsVertex_fixOmega](https://github.com/key4hep/k4SimDelphes/assets/5372932/9c083845-9bcb-4ae3-ac20-f7cd999ac2e8)
