### PR TITLE
Change ROOTFrame{Writer,Reader} to ROOT{Writer,Reader} when possible

### DIFF
--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -3,7 +3,11 @@
 #include "k4SimDelphes/DelphesEDM4HepOutputConfiguration.h"
 
 #include "podio/Frame.h"
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include "podio/ROOTReader.h"
+#else
 #include "podio/ROOTFrameWriter.h"
+#endif
 
 #include "ExRootAnalysis/ExRootConfReader.h"
 #include "ExRootAnalysis/ExRootProgressBar.h"
@@ -16,7 +20,11 @@
 static bool interrupted = false;
 void        SignalHandler(int /*si*/) { interrupted = true; }
 
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+template <typename WriterT = podio::ROOTWriter> int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
+#else
 template <typename WriterT = podio::ROOTFrameWriter> int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
+#endif
   using namespace k4SimDelphes;
 
   // We can't make this a unique_ptr because it interferes with whatever ROOT is

--- a/tests/src/compare_delphes_converter_outputs.cpp
+++ b/tests/src/compare_delphes_converter_outputs.cpp
@@ -6,7 +6,11 @@
 #include "edm4hep/utils/kinematics.h"
 
 #include "podio/Frame.h"
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+#include "podio/ROOTReader.h"
+#else
 #include "podio/ROOTFrameReader.h"
+#endif
 
 #include "ExRootAnalysis/ExRootTreeBranch.h"
 #include "ExRootAnalysis/ExRootTreeReader.h"
@@ -329,7 +333,11 @@ void compareMET(const TClonesArray* delphesColl, const edm4hep::ReconstructedPar
 
 int main(int argc, char* argv[]) {
   // do the necessary setup work for podio and delphes first
+#if PODIO_VERSION_MAJOR > 0 || (PODIO_VERSION_MAJOR == 0 && PODIO_VERSION_MINOR >= 99)
+  podio::ROOTReader reader{};
+#else
   podio::ROOTFrameReader reader{};
+#endif
   reader.openFile(argv[1]);
 
   auto chain = std::make_unique<TChain>("Delphes");


### PR DESCRIPTION
BEGINRELEASENOTES
- Change ROOTFrame{Writer,Reader} to ROOT{Writer,Reader} following https://github.com/AIDASoft/podio/pull/549

ENDRELEASENOTES

When the #ifs are removed we should specify a requirement of podio 0.99 or greater