### PR TITLE
Don't set radiusOfInnermostHit for EDM4hep tracks

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -253,9 +253,6 @@ namespace k4SimDelphes {
       trackerHit2.setPosition(position2);
       track.addToTrackerHits(trackerHit2);
 
-      track.setRadiusOfInnermostHit(
-          sqrt(delphesCand->XFirstHit * delphesCand->XFirstHit + delphesCand->YFirstHit * delphesCand->YFirstHit));
-
       trackCollection->push_back(track);
       pathLengthCollection->push_back(delphesCand->L);
 


### PR DESCRIPTION
see https://github.com/key4hep/EDM4hep/pull/326. Can be merged at any time, doesn't need https://github.com/key4hep/EDM4hep/pull/326

BEGINRELEASENOTES
- Don't set setRadiusOfInnermostHit for EDM4hep tracks

ENDRELEASENOTES