### PR TITLE
Make ROOT load libraries without the .so extension

### DIFF
--- a/examples/read_delphes.C
+++ b/examples/read_delphes.C
@@ -89,7 +89,7 @@ template <typename RecoT> int getNType(const Jet* jet) {
 
 // Following delphes/examples/Example3.C (more or less)
 void read_delphes(const char* inputfile) {
-  gSystem->Load("libDelphes.so");
+  gSystem->Load("libDelphes");
 
   auto* chain = new TChain("Delphes");
   chain->Add(inputfile);

--- a/examples/read_edm4hep.C
+++ b/examples/read_edm4hep.C
@@ -94,11 +94,11 @@ void fillHists(TH1F* hDeltaPt, TH1F* hDeltaE, edm4hep::ConstReconstructedParticl
 }
 
 void read_edm4hep(std::string&& inputfile) {
-  gSystem->Load("libpodio.so");
-  gSystem->Load("libpodioDict.so");
-  gSystem->Load("libpodioRootIO.so");
-  gSystem->Load("libedm4hep.so");
-  gSystem->Load("libedm4hepDict.so");
+  gSystem->Load("libpodio");
+  gSystem->Load("libpodioDict");
+  gSystem->Load("libpodioRootIO");
+  gSystem->Load("libedm4hep");
+  gSystem->Load("libedm4hepDict");
 
   auto reader = podio::ROOTReader();
   reader.openFile(inputfile);


### PR DESCRIPTION
See https://github.com/key4hep/EDM4hep/pull/339 and https://github.com/key4hep/EDM4hep/issues/338