### PR TITLE
Do not use GaudiAlg, use Gaudi::Algorithm instead

### DIFF
--- a/framework/k4SimDelphes/CMakeLists.txt
+++ b/framework/k4SimDelphes/CMakeLists.txt
@@ -8,7 +8,6 @@ gaudi_add_module(k4SimDelphesPlugins
                  LINK k4FWCore::k4FWCore
                       k4FWCore::k4Interface
                       DelphesEDM4HepConverter
-                      Gaudi::GaudiAlgLib
                       Gaudi::GaudiKernel
                       EDM4HEP::edm4hep
                       ROOT::Core

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -46,7 +46,7 @@ StatusCode k4SimDelphesAlg::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode k4SimDelphesAlg::execute(const EventContext&) {
+StatusCode k4SimDelphesAlg::execute(const EventContext&) const {
   verbose() << "Execute k4SimDelphesAlg... " << endmsg;
   m_allParticleOutputArray->Clear();
   m_stableParticleOutputArray->Clear();

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -11,7 +11,7 @@ DECLARE_COMPONENT(k4SimDelphesAlg)
 using namespace k4SimDelphes;
 
 k4SimDelphesAlg::k4SimDelphesAlg(const std::string& name, ISvcLocator* svcLoc)
-    : GaudiAlgorithm(name, svcLoc), m_eventDataSvc("EventDataSvc", "k4SimDelphesAlg") {
+  : Gaudi::Algorithm(name, svcLoc), m_eventDataSvc("EventDataSvc", "k4SimDelphesAlg") {
   declareProperty("GenParticles", m_InputMCParticles, "(Input) Collection of generated particles");
 }
 

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -11,7 +11,7 @@ DECLARE_COMPONENT(k4SimDelphesAlg)
 using namespace k4SimDelphes;
 
 k4SimDelphesAlg::k4SimDelphesAlg(const std::string& name, ISvcLocator* svcLoc)
-  : Gaudi::Algorithm(name, svcLoc), m_eventDataSvc("EventDataSvc", "k4SimDelphesAlg") {
+    : Gaudi::Algorithm(name, svcLoc), m_eventDataSvc("EventDataSvc", "k4SimDelphesAlg") {
   declareProperty("GenParticles", m_InputMCParticles, "(Input) Collection of generated particles");
 }
 

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -46,7 +46,7 @@ StatusCode k4SimDelphesAlg::initialize() {
   return StatusCode::SUCCESS;
 }
 
-StatusCode k4SimDelphesAlg::execute() {
+StatusCode k4SimDelphesAlg::execute(const EventContext&) {
   verbose() << "Execute k4SimDelphesAlg... " << endmsg;
   m_allParticleOutputArray->Clear();
   m_stableParticleOutputArray->Clear();

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.h
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.h
@@ -11,7 +11,7 @@
 #include "k4FWCore/DataWrapper.h"
 #include "k4FWCore/PodioDataSvc.h"
 
-#include "GaudiAlg/GaudiAlgorithm.h"
+#include "Gaudi/Algorithm.h"
 
 #include "modules/Delphes.h"
 
@@ -26,19 +26,19 @@ namespace edm4hep {
  *  Main Algorithm to run Delphes, getting MCParticle input, producing
  *  ReconstructedParticle output.
  */
-class k4SimDelphesAlg : public GaudiAlgorithm {
+class k4SimDelphesAlg : public Gaudi::Algorithm {
 public:
   k4SimDelphesAlg(const std::string& name, ISvcLocator* svcLoc);
 
   virtual StatusCode initialize();
-  virtual StatusCode execute();
+  virtual StatusCode execute(const EventContext&);
   virtual StatusCode finalize();
 
 private:
   /// Input from Generator
-  DataHandle<edm4hep::MCParticleCollection> m_InputMCParticles{"GenParticles", Gaudi::DataHandle::Reader, this};
+  mutable DataHandle<edm4hep::MCParticleCollection> m_InputMCParticles{"GenParticles", Gaudi::DataHandle::Reader, this};
   /// Output from Delphes
-  DataHandle<edm4hep::ReconstructedParticleCollection> m_OutputRecParticles{"RecParticlesDelphes",
+  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_OutputRecParticles{"RecParticlesDelphes",
                                                                             Gaudi::DataHandle::Writer, this};
 
   // Delphes detector card to be read in
@@ -51,17 +51,17 @@ private:
   std::unique_ptr<Delphes>                               m_Delphes{nullptr};
   std::unique_ptr<ExRootConfReader>                      m_confReader{nullptr};
   std::unique_ptr<k4SimDelphes::DelphesEDM4HepConverter> m_edm4hepConverter{nullptr};
-  TObjArray*                                             m_allParticleOutputArray{nullptr};
-  TObjArray*                                             m_stableParticleOutputArray{nullptr};
-  TObjArray*                                             m_partonOutputArray{nullptr};
+  mutable TObjArray*                                             m_allParticleOutputArray{nullptr};
+  mutable TObjArray*                                             m_stableParticleOutputArray{nullptr};
+  mutable TObjArray*                                             m_partonOutputArray{nullptr};
 
-  ExRootTreeWriter* m_treeWriter{nullptr};
+  mutable ExRootTreeWriter* m_treeWriter{nullptr};
   TTree*            m_converterTree{nullptr};
 
   // since branch names are taken from delphes config
   // and not declared as data handles,
   // need podiodatasvc directly
-  PodioDataSvc*                   m_podioDataSvc;
+  mutable PodioDataSvc*                   m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
 };
 

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.h
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.h
@@ -31,7 +31,7 @@ public:
   k4SimDelphesAlg(const std::string& name, ISvcLocator* svcLoc);
 
   virtual StatusCode initialize();
-  virtual StatusCode execute(const EventContext&);
+  virtual StatusCode execute(const EventContext&) const;
   virtual StatusCode finalize();
 
 private:

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.h
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.h
@@ -39,7 +39,7 @@ private:
   mutable DataHandle<edm4hep::MCParticleCollection> m_InputMCParticles{"GenParticles", Gaudi::DataHandle::Reader, this};
   /// Output from Delphes
   mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_OutputRecParticles{"RecParticlesDelphes",
-                                                                            Gaudi::DataHandle::Writer, this};
+                                                                                    Gaudi::DataHandle::Writer, this};
 
   // Delphes detector card to be read in
   /// Name of Delphes tcl config file with detector and simulation parameters
@@ -51,17 +51,17 @@ private:
   std::unique_ptr<Delphes>                               m_Delphes{nullptr};
   std::unique_ptr<ExRootConfReader>                      m_confReader{nullptr};
   std::unique_ptr<k4SimDelphes::DelphesEDM4HepConverter> m_edm4hepConverter{nullptr};
-  mutable TObjArray*                                             m_allParticleOutputArray{nullptr};
-  mutable TObjArray*                                             m_stableParticleOutputArray{nullptr};
-  mutable TObjArray*                                             m_partonOutputArray{nullptr};
+  mutable TObjArray*                                     m_allParticleOutputArray{nullptr};
+  mutable TObjArray*                                     m_stableParticleOutputArray{nullptr};
+  mutable TObjArray*                                     m_partonOutputArray{nullptr};
 
   mutable ExRootTreeWriter* m_treeWriter{nullptr};
-  TTree*            m_converterTree{nullptr};
+  TTree*                    m_converterTree{nullptr};
 
   // since branch names are taken from delphes config
   // and not declared as data handles,
   // need podiodatasvc directly
-  mutable PodioDataSvc*                   m_podioDataSvc;
+  mutable PodioDataSvc*           m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
 };
 


### PR DESCRIPTION
These are the changes needed not to use GaudiAlg, which will be removed (maybe soon) in Gaudi.

BEGINRELEASENOTES
- Do not link to GaudiAlgLib
- Add the necessary changes to the algorithm, use `Gaudi::Algorithm`, make `execute()` const and add a `const EventContext&`
- Add mutable to some elements that are changed; add const to some functions so that they can be called inside `execute(const EventContext&) const`

ENDRELEASENOTES