### PR TITLE
Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,31 +20,10 @@ SET( ${PROJECT_NAME}_VERSION_PATCH 2 )
 SET( ${PROJECT_NAME}_VERSION
   "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}" )
 
-
-#--- Such that the binaries in install are properly linked --------------------
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE CACHE BOOL "RPATH USE LINK PATH")
-
-#--- Declare C++ Standard -----------------------------------------------------
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-message (STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
-
+include(cmake/Key4hepConfig.cmake)
 
 #-- Use GNU-style hierarchy for installing build products ----------------------
 include(GNUInstallDirs)
-
-#--- setup build type (and default) if supported -------------------------------
-if (NOT CMAKE_CONFIGURATION_TYPES)
-  if (NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE RelWithDebInfo
-      CACHE STRING "Choose the type of build, options are: None|Release|MinSizeRel|Debug|RelWithDebInfo" FORCE)
-  else()
-    set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE}
-      CACHE STRING "Choose the type of build, options are: None|Release|MinSizeRel|Debug|RelWithDebInfo" FORCE)
-  endif()
-endif()
 
 #--- add version files ---------------------------------------------------------
 configure_file(${PROJECT_SOURCE_DIR}/k4SimDelphesVersion.h

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -204,7 +204,6 @@ namespace k4SimDelphes {
     }
 
     // mother-daughter relations
-    const auto nElements = collection->size();
     for (int iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       const auto* delphesCand = static_cast<GenParticle*>(delphesCollection->At(iCand));
       auto        cand        = collection->at(iCand);
@@ -608,7 +607,7 @@ namespace k4SimDelphes {
 
     // Mothers
     // Only set parents if not accessing out of bounds
-    const auto safeSetParent = [&mcParticles, &particle](int index) {
+    const auto safeSetParent = [&mcParticles, &particle](size_t index) {
       if (index < mcParticles.size()) {
         particle.addToParents(mcParticles[index]);
       }
@@ -637,7 +636,7 @@ namespace k4SimDelphes {
     }
 
     // Daughters
-    const auto safeSetDaughter = [&mcParticles, &particle](int index) {
+    const auto safeSetDaughter = [&mcParticles, &particle](size_t index) {
       if (index < mcParticles.size()) {
         particle.addToDaughters(mcParticles[index]);
       }

--- a/standalone/src/PythiaEvtGen_Interface.cc
+++ b/standalone/src/PythiaEvtGen_Interface.cc
@@ -82,9 +82,7 @@ void PythiaEvtGen_Interface::add_inclusive(std::string decayfile, int seed) {
   std::list<EvtDecayBase*> extraModels = genList.getListOfModels();
   // Random engine:
 
-  EvtRandomEngine* eng = 0;
-  //eng = new EvtMTRandomEngine(seed);  // look out, this works only with C++11, OLD C++ use: eng = new EvtSimpleRandomEngine()
-  eng = new EvtSimpleRandomEngine();
+  EvtRandomEngine* eng = new EvtMTRandomEngine(seed);
   EvtRandom::setRandomEngine(eng);
 
   if (debug)
@@ -105,7 +103,7 @@ bool PythiaEvtGen_Interface::check_Signal_Appereance() {
   //signal_map= new int[NOfSignal][10];// here we assume we won't have more then 10 signal candidates
   signal_map = std::vector<std::vector<int>>(NOfSignal);  // resetting this vector//;(NOfSignal);
   //signal_map= new int*[NOfSignal];
-  for (int i = 0; i < NOfSignal; ++i) {
+  for (auto i = 0u; i < NOfSignal; ++i) {
     //    signal_map[i] = new int[10]; // here we assume we won't have more then 10 signal candidates
     signal_map[i] = std::vector<int>(10);
   }
@@ -117,7 +115,6 @@ bool PythiaEvtGen_Interface::check_Signal_Appereance() {
     pythia->event.list();
   Pythia8::Event& event = pythia->event;
 
-  double wgt(1.);
   //loop over particles to find candidates that mach what we need from the decay
   for (int iPro = 0; iPro < event.size(); ++iPro) {
     Pythia8::Particle* part = &event[iPro];
@@ -138,7 +135,7 @@ bool PythiaEvtGen_Interface::check_Signal_Appereance() {
     }
   }
   // now checking if we have all B candidates
-  int sum = 0;
+  size_t sum = 0;
   for (unsigned i = 0; i < NOfSignal_list.size(); i++) {
     if (NOfSignal_list[i] > 0)
       sum += 1;
@@ -159,7 +156,7 @@ void PythiaEvtGen_Interface::decay_signals() {
   if (debug)
     std::cout << "In decay_signals" << std::endl;
   unsigned NOfSignal = motherIDs.size();
-  for (int i_sig = 0; i_sig < NOfSignal; i_sig++)  // loop over signal B's
+  for (auto i_sig = 0u; i_sig < NOfSignal; i_sig++)  // loop over signal B's
   {
     int randomsignal = (rand() % NOfSignal_list[i_sig]);
     if (debug)

--- a/tests/src/compare_delphes_converter_outputs.cpp
+++ b/tests/src/compare_delphes_converter_outputs.cpp
@@ -133,7 +133,7 @@ bool compareMCRelations(const DelphesT* delphesCand, edm4hep::ReconstructedParti
  */
 void compareCollectionsBasic(const TClonesArray* delphesColl, const podio::CollectionBase& edm4hepColl,
                              const std::string collName) {
-  if (delphesColl->GetEntries() != edm4hepColl.size()) {
+  if (delphesColl->GetEntries() != static_cast<int>(edm4hepColl.size())) {
     std::cerr << "Sizes of collection \'" << collName << "\' disagree: " << delphesColl->GetEntries() << " vs "
               << edm4hepColl.size() << std::endl;
     std::exit(1);
@@ -195,10 +195,10 @@ void compareCollectionElements(const TClonesArray* delphesColl, const edm4hep::M
       std::exit(1);
     }
 
-    const auto assertMsg = [](const std::string& collName, const int index, const int relIndex,
+    const auto assertMsg = [](const std::string& name, const int index, const int relIndex,
                               const std::string& relation) {
       return relation + std::to_string(relIndex) + " of particle " + std::to_string(index) +
-             " differs between delphes and edm4hep output in collection \'" + collName + "\'";
+             " differs between delphes and edm4hep output in collection \'" + name + "\'";
     };
 
     // compare the parents
@@ -290,17 +290,17 @@ void compareJets(const TClonesArray* delphesColl, const edm4hep::ReconstructedPa
     const auto  edm4hepCand = edm4hepColl[i];
     assertSameKinematics(delphesCand, edm4hepCand, stdErrorMessage, collName, i);
 
-    if (delphesCand->Constituents.GetEntries() != edm4hepCand.getParticles().size()) {
+    if (delphesCand->Constituents.GetEntries() != static_cast<int>(edm4hepCand.getParticles().size())) {
       std::cerr << "Number of Jet constitutents in Jet " << i
                 << " differs between delphes and edm4hep output: " << delphesCand->Constituents.GetEntries() << " vs "
                 << edm4hepCand.getParticles().size() << std::endl;
       std::exit(1);
     }
 
-    const auto assertMsg = [](const std::string& collName, const int index, const int iConst) {
+    const auto assertMsg = [](const std::string& name, const int index, const int iConst) {
       return std::string("Jet constituent ") + std::to_string(iConst) +
              " has different kinematics in delphes and in edm4hep in Jet " + std::to_string(index) +
-             " in collection \'" + collName + "\'";
+             " in collection \'" + name + "\'";
     };
 
     for (int j = 0; j < delphesCand->Constituents.GetEntries(); ++j) {
@@ -339,7 +339,7 @@ void compareMET(const TClonesArray* delphesColl, const edm4hep::ReconstructedPar
   assertSameKinematics(delphesMET, edm4hepMET, []() { return "MET differs between delphes and edm4hep output"; });
 }
 
-int main(int argc, char* argv[]) {
+int main(int, char* argv[]) {
   // do the necessary setup work for podio and delphes first
   podio::ROOTReader reader{};
   reader.openFile(argv[1]);
@@ -388,8 +388,8 @@ int main(int argc, char* argv[]) {
     compareCollectionsBasic(photonCollDelphes, photonColl, "Photon");
     compareCollectionElements<Photon>(photonCollDelphes, photonColl, "Photon");
 
-    auto&     recoColl = frame.get<edm4hep::ReconstructedParticleCollection>("ReconstructedParticles");
-    const int nRecos   = tracks->GetEntries() + ecalClusters->GetEntries() + hcalClusters->GetEntries();
+    auto&          recoColl = frame.get<edm4hep::ReconstructedParticleCollection>("ReconstructedParticles");
+    const unsigned nRecos   = tracks->GetEntries() + ecalClusters->GetEntries() + hcalClusters->GetEntries();
 
     if (nRecos != recoColl.size()) {
       std::cerr << "The global ReconstructedParticle collection and the original delphes collections differ in size: "


### PR DESCRIPTION
See https://github.com/key4hep/EDM4hep/pull/359.

BEGINRELEASENOTES
- Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.
- Fix compiler warnings that were uncovered by this

ENDRELEASENOTES