### PR TITLE
Fix flaky tests by disregarding order of mc-reco links

### DIFF
--- a/.github/workflows/key4hep-build.yaml
+++ b/.github/workflows/key4hep-build.yaml
@@ -26,8 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: key4hep/key4hep-actions/key4hep-build@ctest-extra-args
+    - uses: key4hep/key4hep-actions/key4hep-build@main
       with:
         build_type: ${{ matrix.build_type }}
         image: ${{ matrix.image }}
-        ctest_extra_args: --repeat until-pass:5

--- a/.github/workflows/key4hep-build.yaml
+++ b/.github/workflows/key4hep-build.yaml
@@ -26,7 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: key4hep/key4hep-actions/key4hep-build@main
+    - uses: key4hep/key4hep-actions/key4hep-build@ctest-extra-args
       with:
         build_type: ${{ matrix.build_type }}
         image: ${{ matrix.image }}
+        ctest_extra_args: --repeat until-pass:5


### PR DESCRIPTION
BEGINRELEASENOTES
- Make MC-Reco links comparisons pass even if they are not the same order in EDM4hep and Delphes as long as all the links are present.

ENDRELEASENOTES

~- [ ] Needs https://github.com/key4hep/key4hep-actions/pull/7~

As already stated in the inline comment: Delphes seems to write these in different orders even with the same random seed. It seems to only happen during writing of the Delphes file, as the EDM4hep files that come out of the converter are the same. I have done a `diff <(podio-dump -d -e <offending-event> <run_1.root>) <(podio-dump -d -e <offending-event> <run-2.root>)` and that yields no differences in the files apart from the obviously different file names.

Given all that, I think this is the most reasonable fix we can make.

Fixes #129 