### PR TITLE
Split ParticleID collection into smaller collections

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -158,7 +158,6 @@ namespace k4SimDelphes {
     double m_magneticFieldBz;  // necessary for determining track parameters
 
     std::string m_recoCollName;
-    std::string m_particleIDName;
     std::string m_recoMCLinkCollName;
 
     // map from UniqueIDs (delphes generated particles) to MCParticles

--- a/converter/include/k4SimDelphes/DelphesEDM4HepOutputConfiguration.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepOutputConfiguration.h
@@ -82,11 +82,6 @@ namespace k4SimDelphes {
      * generated to reconstructed particles.
      */
     std::string RecoMCParticleLinkCollectionName{"MCRecoAssociations"};
-
-    /**
-     * Name of the ParticleIDCollection holding the ctags / isolation variables.
-     */
-    std::string ParticleIDCollectionName{"ParticleIDs"};
   };
 
   template <typename T> std::ostream& operator<<(std::ostream& os, std::vector<T> const& container) {

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -344,9 +344,9 @@ namespace k4SimDelphes {
   }
 
   void DelphesEDM4HepConverter::processJets(const TClonesArray* delphesCollection, std::string const& branch) {
-    auto* jetCollection = createCollection<edm4hep::ReconstructedParticleCollection>(branch);
+    auto* jetCollection         = createCollection<edm4hep::ReconstructedParticleCollection>(branch);
     auto* idCollection_HF_tags  = createCollection<edm4hep::ParticleIDCollection>(branch + "_HF_tags");
-    auto* idCollection_tau_tags  = createCollection<edm4hep::ParticleIDCollection>(branch + "_tau_tags");
+    auto* idCollection_tau_tags = createCollection<edm4hep::ParticleIDCollection>(branch + "_tau_tags");
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Jet*>(delphesCollection->At(iCand));

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -79,7 +79,6 @@ namespace k4SimDelphes {
                                                    OutputSettings const& outputSettings, double magFieldBz)
       : m_magneticFieldBz(magFieldBz),
         m_recoCollName(outputSettings.RecoParticleCollectionName),
-        m_particleIDName(outputSettings.ParticleIDCollectionName),
         m_recoMCLinkCollName(outputSettings.RecoMCParticleLinkCollectionName) {
     for (const auto& branch : branches) {
       if (contains(PROCESSING_ORDER, branch.className)) {
@@ -224,7 +223,7 @@ namespace k4SimDelphes {
     magFieldCollection->push_back(m_magneticFieldBz);
 
     auto* mcRecoRelations = getCollection<edm4hep::RecoMCParticleLinkCollection>(m_recoMCLinkCollName);
-    auto* idCollection    = getCollection<edm4hep::ParticleIDCollection>(m_particleIDName);
+    auto* idCollection    = createCollection<edm4hep::ParticleIDCollection>(branch + "_PID");
     auto* trackerHitColl  = getCollection<edm4hep::TrackerHit3DCollection>(TRACKERHIT_OUTPUT_NAME);
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
@@ -346,7 +345,7 @@ namespace k4SimDelphes {
 
   void DelphesEDM4HepConverter::processJets(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* jetCollection = createCollection<edm4hep::ReconstructedParticleCollection>(branch);
-    auto* idCollection  = getCollection<edm4hep::ParticleIDCollection>(m_particleIDName);
+    auto* idCollection  = createCollection<edm4hep::ParticleIDCollection>(branch + "_tags");
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Jet*>(delphesCollection->At(iCand));
@@ -509,9 +508,6 @@ namespace k4SimDelphes {
     }
     if (m_collections.find(m_recoMCLinkCollName) == m_collections.end()) {
       createCollection<edm4hep::RecoMCParticleLinkCollection>(m_recoMCLinkCollName);
-    }
-    if (m_collections.find(m_particleIDName) == m_collections.end()) {
-      createCollection<edm4hep::ParticleIDCollection>(m_particleIDName);
     }
     if (m_collections.find(TRACKERHIT_OUTPUT_NAME) == m_collections.end()) {
       createCollection<edm4hep::TrackerHit3DCollection>(TRACKERHIT_OUTPUT_NAME);

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -345,12 +345,14 @@ namespace k4SimDelphes {
 
   void DelphesEDM4HepConverter::processJets(const TClonesArray* delphesCollection, std::string const& branch) {
     auto* jetCollection = createCollection<edm4hep::ReconstructedParticleCollection>(branch);
-    auto* idCollection  = createCollection<edm4hep::ParticleIDCollection>(branch + "_tags");
+    auto* idCollection_HF_tags  = createCollection<edm4hep::ParticleIDCollection>(branch + "_HF_tags");
+    auto* idCollection_tau_tags  = createCollection<edm4hep::ParticleIDCollection>(branch + "_tau_tags");
 
     for (auto iCand = 0; iCand < delphesCollection->GetEntries(); ++iCand) {
       auto* delphesCand = static_cast<Jet*>(delphesCollection->At(iCand));
       auto  jet         = jetCollection->create();
-      auto  id          = idCollection->create();
+      auto  id_HF_tag   = idCollection_HF_tags->create();
+      auto  id_tau_tag  = idCollection_tau_tags->create();
 
       // NOTE: Filling the jet with the information delievered by Delphes, which
       // is not necessarily the same as the sum of its constituents (filled below)
@@ -361,9 +363,10 @@ namespace k4SimDelphes {
       jet.setMomentum({(float)momentum.Px(), (float)momentum.Py(), (float)momentum.Pz()});
 
       // id.addToParameters(delphesCand->IsolationVar);
-      id.addToParameters(delphesCand->BTag);
-      id.addToParameters(delphesCand->TauTag);
-      id.setParticle(jet);
+      id_HF_tag.addToParameters(delphesCand->BTag);
+      id_tau_tag.addToParameters(delphesCand->TauTag);
+      id_HF_tag.setParticle(jet);
+      id_tau_tag.setParticle(jet);
 
       const auto& constituents = delphesCand->Constituents;
       for (auto iConst = 0; iConst < constituents.GetEntries(); ++iConst) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Split the global `ParticleIDs` collection into several smaller collections to facilitate downstream usage after the reversal of the `ParticleID` - `ReconstructedParticle` relation direction in [EDM4hep#268](https://github.com/key4hep/EDM4hep/pull/268).
  - `Tracks` will get a `ParticleIDCollection` with the suffix `_PID`
  - `Jets` will get a `ParticleIDCollection` with the suffix `_HF_tags` for any heavy flavor tags, and `_tau_tags` for any tau tags.

ENDRELEASENOTES

Having one large ParticleID collection made sense historically before EDM4hep reversed the direction of the ReconstructedParticle -> ParticleID relation. Since now ParticleIDs point to the ReconstructedParticles it's easier to handle downstream (and especially in FCCAnalyses) if there are several smaller and more specific ParticleID collections for each of the input collections that are converted.

@bistapf since we are at it should we also think about splitting the tags for the jets into separate collections?
