### PR TITLE
Only Clear the LHEF reader if it's initialized and used

### DIFF
--- a/standalone/src/DelphesPythia8Reader.h
+++ b/standalone/src/DelphesPythia8Reader.h
@@ -152,7 +152,9 @@ public:
         return false;
       }
       modularDelphes->Clear();
-      reader->Clear();
+      if (reader) {
+        reader->Clear();
+      }
     }
     m_readStopWatch.Stop();
     m_procStopWatch.Start();


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to not crash in cases where the LHEF reader has not been initialized in the Pythia reader

ENDRELEASENOTES

Example of random crashes we were observing:
```
** 1424 events processed
 *** Break *** segmentation violation



===========================================================
There was a crash.
This is the entire stack trace of all threads:
===========================================================
#0  0x00007f658b6d89fa in wait4 () from /lib64/libc.so.6
#1  0x00007f658b64b243 in do_system () from /lib64/libc.so.6
#2  0x00007f658c117713 in TUnixSystem::StackTrace() () from /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2024-09-21/x86_64-almalinux9-gcc14.2.0-opt/root/6.32.04-vms5ij/lib/libCore.so.6.32
#3  0x00007f658c117064 in TUnixSystem::DispatchSignals(ESignals) () from /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2024-09-21/x86_64-almalinux9-gcc14.2.0-opt/root/6.32.04-vms5ij/lib/libCore.so.6.32
#4  <signal handler called>
#5  0x00007f658e14fd20 in DelphesLHEFReader::Clear() () from /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2024-11-13/x86_64-almalinux9-gcc14.2.0-opt/delphes/0a4a3993d08465d7599174baeb364703b8a73fa4_develop-76ldcg/lib/libDelphes.so
#6  0x000000000042d316 in DelphesPythia8Reader::readEvent (this=0x7ffc30c991c0, modularDelphes=<optimized out>, allParticleOutputArray=0x3c292a0, stableParticleOutputArray=0x428ddb0, partonOutputArray=0x428de00) at /home/jsmiesko/emre/k4SimDelphes/standalone/src/DelphesPythia8Reader.h:155
#7  0x000000000043db97 in doit<podio::ROOTWriter> (argc=argc
entry=5, argv=argv
entry=0x7ffc30c99438, inputReader=...) at /home/jsmiesko/emre/k4SimDelphes/standalone/src/DelphesMain.h:63
#8  0x00000000004131e4 in main (argc=5, argv=0x7ffc30c99438) at /home/jsmiesko/emre/k4SimDelphes/standalone/src/DelphesPythia8_EDM4HEP.cpp:7
===========================================================
```