### PR TITLE
Fixing conversion of ScalarHT and make it a UserDataCollection

### DIFF
--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -435,11 +435,9 @@ namespace k4SimDelphes {
   }
 
   void DelphesEDM4HepConverter::processScalarHT(const TClonesArray* delphesCollection, std::string const& branch) {
-    auto* collection  = createCollection<edm4hep::ParticleIDCollection>(branch);
+    auto* collection  = createCollection<podio::UserDataCollection<float>>(branch);
     auto* delphesCand = static_cast<ScalarHT*>(delphesCollection->At(0));
-
-    auto cand = collection->create();
-    cand.addToParameters(delphesCand->HT);
+    collection->push_back(delphesCand->HT);
   }
 
   template <typename DelphesT>

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -39,8 +39,8 @@ namespace k4SimDelphes {
    * ensure that products required by later stages are producd early enough
    */
   constexpr std::array<std::string_view, 10> PROCESSING_ORDER = {
-      "GenParticle", "Track",     "Tower",    "ParticleFlowCandidate", "Muon", "Electron", "Photon",
-      "Jet",         "MissingET", "SclalarHT"};
+      "GenParticle", "Track",     "Tower",   "ParticleFlowCandidate", "Muon", "Electron", "Photon",
+      "Jet",         "MissingET", "ScalarHT"};
 
   template <size_t N>
   void sortBranchesProcessingOrder(std::vector<BranchSettings>&           branches,

--- a/doc/output_config.md
+++ b/doc/output_config.md
@@ -109,7 +109,7 @@ classes. For the conversion the Delphes classes are taken from the `TreeWriter`
 | `Electron`              | `ReconstructedParticle` (subset collection)       |
 | `Photon`                | `ReconstructedParticle` (subset collection)       |
 | `MissingET`             | `ReconstructedParticle`                           |
-| `ScalarHT`              | `ParticleID`                                      |
+| `ScalarHT`              | `UserDataCollection`                              |
 | `ParticleFlowCandidate` | `ReconstructedParticle`                           |
 | n/a                     | `RecoMCParticleLink`                              |
 

--- a/doc/output_config.md
+++ b/doc/output_config.md
@@ -109,7 +109,7 @@ classes. For the conversion the Delphes classes are taken from the `TreeWriter`
 | `Electron`              | `ReconstructedParticle` (subset collection)       |
 | `Photon`                | `ReconstructedParticle` (subset collection)       |
 | `MissingET`             | `ReconstructedParticle`                           |
-| `ScalarHT`              | `UserDataCollection`                              |
+| `ScalarHT`              | `UserDataCollection<float>`                       |
 | `ParticleFlowCandidate` | `ReconstructedParticle`                           |
 | n/a                     | `RecoMCParticleLink`                              |
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Use a `UserDataCollection<float>` to store the `ScalarHT` output from Delphes instead of a `ParticleIDCollection`.
- Fix a typo in the converter source code that prevented the `ScalarHT` collection from Delphes from being converted, even if explicitly requested in the output config.

ENDRELEASENOTES

- [x] WIP, because what is the reasoning behind the `ScalarHT` collection being a `ParticleIDCollection`? This comes with a bunch of unneccessary, confusing parameters that don't apply (PDG, likelihood, algorithmType, .. ). Should we change this to e.g. `UserDataCollection` or how it's done for `MissingET`? 
