### PR TITLE
Use non-deprecated config name in example

### DIFF
--- a/framework/k4SimDelphes/examples/options/edm4hep_output_config.tcl
+++ b/framework/k4SimDelphes/examples/options/edm4hep_output_config.tcl
@@ -8,5 +8,5 @@ module EDM4HepOutput EDM4HepOutput {
     add MissingETCollections             MissingET
     add ScalarHTCollections              ScalarHT
     set RecoParticleCollectionName       ReconstructedParticles
-    set MCRecoAssociationCollectionName  RecoMCLink
+    set RecoMCParticleLinkCollectionName RecoMCLink
  }


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the non-deprecated `MCRecoParticleLinkCollectionName` in the example output configuration

ENDRELEASENOTES

Missed in #140 (originally missed in #128)
