### PR TITLE
Fix deprecation warnings related to PodioDataSvc

### DIFF
--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.cpp
@@ -36,7 +36,6 @@ StatusCode k4SimDelphesAlg::initialize() {
 
   // data service
   m_eventDataSvc.retrieve().ignore();
-  m_podioDataSvc = dynamic_cast<PodioDataSvc*>(m_eventDataSvc.get());
 
   const auto branches = getBranchSettings(m_confReader->GetParam("TreeWriter::Branch"));
   m_outputConfig = getEDM4hepOutputSettings(m_DelphesOutputSettings.value().c_str());
@@ -74,13 +73,13 @@ StatusCode k4SimDelphesAlg::execute(const EventContext&) const {
       auto new_c = m_edm4hepConverter->createExternalRecoMCLinks(mapSimDelphes);
       DataWrapper<podio::CollectionBase>* wrapper = new DataWrapper<podio::CollectionBase>();
       wrapper->setData(new_c);
-      m_podioDataSvc->registerObject("/Event", "/" + std::string(c.first), wrapper).ignore();
+      m_eventDataSvc->registerObject("/Event", "/" + std::string(c.first), wrapper).ignore();
       continue;
     }
 
     DataWrapper<podio::CollectionBase>* wrapper = new DataWrapper<podio::CollectionBase>();
     wrapper->setData(c.second.release()); // DataWrapper takes ownership
-    m_podioDataSvc->registerObject("/Event", "/" + std::string(c.first), wrapper).ignore();
+    m_eventDataSvc->registerObject("/Event", "/" + std::string(c.first), wrapper).ignore();
   }
   m_Delphes->Clear();
 

--- a/framework/k4SimDelphes/src/k4SimDelphesAlg.h
+++ b/framework/k4SimDelphes/src/k4SimDelphesAlg.h
@@ -9,7 +9,6 @@
 
 #include "k4FWCore/DataHandle.h"
 #include "k4FWCore/DataWrapper.h"
-#include "k4FWCore/PodioDataSvc.h"
 
 #include "Gaudi/Algorithm.h"
 
@@ -60,10 +59,6 @@ private:
   mutable ExRootTreeWriter* m_treeWriter{nullptr};
   TTree* m_converterTree{nullptr};
 
-  // since branch names are taken from delphes config
-  // and not declared as data handles,
-  // need podiodatasvc directly
-  mutable PodioDataSvc* m_podioDataSvc;
   ServiceHandle<IDataProviderSvc> m_eventDataSvc;
 };
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix deprecation warnings related to PodioDataSvc, by using `m_eventDataSvc` instead, already present in k4SimDelphesAlg.cpp

ENDRELEASENOTES