### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -30,6 +30,8 @@ class Muon;
 class Electron;
 class Photon;
 
+struct OutputSettings;
+
 namespace k4SimDelphes {
 
 /**
@@ -78,7 +80,6 @@ inline std::vector<BranchSettings> getBranchSettings(ExRootConfParam /*const&*/ 
   return branches;
 }
 
-class OutputSettings;
 
 class DelphesEDM4HepConverter {
 public:

--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -30,9 +30,10 @@ class Muon;
 class Electron;
 class Photon;
 
-struct OutputSettings;
 
 namespace k4SimDelphes {
+
+struct OutputSettings;
 
 /**
  * Classes that will be stored as reconstructed particle with an attached track

--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -30,7 +30,6 @@ class Muon;
 class Electron;
 class Photon;
 
-
 namespace k4SimDelphes {
 
 struct OutputSettings;
@@ -80,7 +79,6 @@ inline std::vector<BranchSettings> getBranchSettings(ExRootConfParam /*const&*/ 
   }
   return branches;
 }
-
 
 class DelphesEDM4HepConverter {
 public:

--- a/standalone/src/DelphesHepMC2Reader.h
+++ b/standalone/src/DelphesHepMC2Reader.h
@@ -119,10 +119,6 @@ public:
 private:
   static constexpr const char* m_appName = "DelphesHepMC";
   int m_numberOfEvents;
-  int m_entry = 0;
-  ExRootTreeReader* m_treeReader = nullptr;
-  TClonesArray* m_branchParticle;
-  TClonesArray* m_branchHepMCEvent;
 
   ExRootTreeWriter* m_treeWriter{nullptr};
   std::unique_ptr<TTree> m_converterTree{nullptr};

--- a/standalone/src/DelphesHepMC3Reader.h
+++ b/standalone/src/DelphesHepMC3Reader.h
@@ -119,10 +119,6 @@ public:
 private:
   static constexpr const char* m_appName = "DelphesHepMC";
   int m_numberOfEvents;
-  int m_entry = 0;
-  ExRootTreeReader* m_treeReader = nullptr;
-  TClonesArray* m_branchParticle;
-  TClonesArray* m_branchHepMCEvent;
 
   ExRootTreeWriter* m_treeWriter{nullptr};
   std::unique_ptr<TTree> m_converterTree{nullptr};

--- a/standalone/src/DelphesPythia8EvtGenReader.h
+++ b/standalone/src/DelphesPythia8EvtGenReader.h
@@ -192,9 +192,6 @@ private:
   Int_t m_spareMode1;
   Double_t m_spareParm1, m_spareParm2;
 
-  TClonesArray* m_branchParticle;
-  TClonesArray* m_branchHepMCEvent;
-
   // for matching
   Pythia8::CombineMatchingInput* combined = 0;
   Pythia8::UserHooks* m_matching = 0;

--- a/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
+++ b/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
@@ -213,9 +213,6 @@ private:
   Int_t m_spareMode1;
   Double_t m_spareParm1, m_spareParm2;
 
-  TClonesArray* m_branchParticle;
-  TClonesArray* m_branchHepMCEvent;
-
   // for matching
   Pythia8::CombineMatchingInput* combined = 0;
   Pythia8::UserHooks* m_matching = 0;

--- a/standalone/src/DelphesPythia8Reader.h
+++ b/standalone/src/DelphesPythia8Reader.h
@@ -193,9 +193,6 @@ private:
   Int_t m_spareMode1;
   Double_t m_spareParm1, m_spareParm2;
 
-  TClonesArray* m_branchParticle;
-  TClonesArray* m_branchHepMCEvent;
-
   // resonance decayfilter
   Pythia8::ResonanceDecayFilterHook* m_resonanceDecayFilterHook{nullptr};
 };

--- a/standalone/src/DelphesSTDHEPInputReader.h
+++ b/standalone/src/DelphesSTDHEPInputReader.h
@@ -117,9 +117,7 @@ public:
 private:
   static constexpr const char* m_appName = "DelphesHepMC";
   int m_numberOfEvents;
-  int m_entry = 0;
   bool m_finished = false;
-  ExRootTreeWriter* m_treeReader = nullptr;
 
   FILE* m_inputFile = 0;
   TStopwatch m_readStopWatch, m_procStopWatch;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -11,6 +11,7 @@ if(NOT USE_EXTERNAL_CATCH2)
 endif()
 
 add_executable(k4SimDelphesTests   tests.cpp tests_edm4hepdelphesconverter.cpp)
+target_compile_options(k4SimDelphesTests PRIVATE -Wno-c2y-extensions)
 target_link_libraries(k4SimDelphesTests
                         DelphesEDM4HepConverter
                         EDM4HEP::edm4hep

--- a/tests/unittests/tests.cpp
+++ b/tests/unittests/tests.cpp
@@ -12,10 +12,11 @@
 using namespace k4SimDelphes;
 
 TEST_CASE("k4SimDelphes Converter Tests", "[converter]") {
-  SECTION("DelphesEDM4HepConverter ctor");
+  SECTION("DelphesEDM4HepConverter ctor") {}
   DelphesEDM4HepConverter conv = DelphesEDM4HepConverter(getDelphesCard());
 
-  SECTION("DelphesEDM4HepConverter getCollections");
+  SECTION("DelphesEDM4HepConverter getCollections") {}
   auto coll = conv.getCollections();
   REQUIRE(coll.size() == 0);
 }
+// #pragma GCC diagnostic pop

--- a/tests/unittests/tests_edm4hepdelphesconverter.cpp
+++ b/tests/unittests/tests_edm4hepdelphesconverter.cpp
@@ -9,10 +9,10 @@
 using namespace k4SimDelphes;
 
 TEST_CASE("k4SimDelphes EDM4hep-Delphes Converter tests", "[converter]") {
-  SECTION("DelphesEDM4HepConverter ctor");
+  SECTION("DelphesEDM4HepConverter ctor") {}
   // DelphesEDM4HepConverter conv = DelphesEDM4HepConverter(getDelphesCard());
 
-  SECTION("DelphesEDM4HepConverter getCollections");
+  SECTION("DelphesEDM4HepConverter getCollections") {}
   // auto coll = conv.getCollections();
   REQUIRE(0 == 0);
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix a few compiler warnings, unused variables, empty body of an if, `__COUNTER__` from Catch2 being a C2y extension and other warnings.

ENDRELEASENOTES