### PR TITLE
Remove k4DataSvc and PodioOutput

### DIFF
--- a/framework/k4SimDelphes/examples/options/k4simdelphesalg.py
+++ b/framework/k4SimDelphes/examples/options/k4simdelphesalg.py
@@ -1,14 +1,12 @@
 from Gaudi.Configuration import *
 from GaudiKernel import SystemOfUnits as units
 
-from Configurables import ApplicationMgr
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
 app = ApplicationMgr()
 app.EvtMax = 3
 app.EvtSel = "NONE"
-
-from Configurables import k4DataSvc
-podioevent = k4DataSvc("EventDataSvc")
-app.ExtSvc += [podioevent]
+app.ExtSvc += [EventDataSvc("EventDataSvc")]
 
 from Configurables import ConstPtParticleGun
 guntool1 = ConstPtParticleGun(PdgCodes=[-211], PtMin=50*units.GeV, PtMax=50*units.GeV)
@@ -35,9 +33,8 @@ delphesalg.OutputLevel = VERBOSE
 ApplicationMgr().TopAlg += [delphesalg]
 
 
-from Configurables import PodioOutput
-out = PodioOutput("out", filename = "output_k4SimDelphes.root")
-out.outputCommands = ["keep *"]
-ApplicationMgr().TopAlg += [out]
+iosvc = IOSvc()
+iosvc.Output = "output_k4SimDelphes.root"
+iosvc.outputCommands = ["keep *"]
 
 

--- a/framework/k4SimDelphes/examples/options/k4simdelphesalg_pythia.py
+++ b/framework/k4SimDelphes/examples/options/k4simdelphesalg_pythia.py
@@ -1,14 +1,12 @@
 from Gaudi.Configuration import *
 import os
 
-from Configurables import ApplicationMgr
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
 app = ApplicationMgr()
 app.EvtMax = 100
 app.EvtSel = "NONE"
-
-from Configurables import k4DataSvc
-podioevent = k4DataSvc("EventDataSvc")
-app.ExtSvc += [podioevent]
+app.ExtSvc += [EventDataSvc("EventDataSvc")]
 
 
 from Configurables import PythiaInterface
@@ -46,9 +44,8 @@ delphesalg.OutputLevel = VERBOSE
 ApplicationMgr().TopAlg += [delphesalg]
 
 
-from Configurables import PodioOutput
-out = PodioOutput("out", filename = "output_k4SimDelphes_pythia.root")
-out.outputCommands = ["keep *"]
-ApplicationMgr().TopAlg += [out]
+iosvc = IOSvc()
+iosvc.Output = "output_k4SimDelphes_pythia.root"
+iosvc.outputCommands = ["keep *"]
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the remaining `k4DataSvc` and `PodioOutput` following https://github.com/key4hep/k4FWCore/pull/392

ENDRELEASENOTES