### PR TITLE
Check if ReadEvent exists, in that case use it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,18 @@ find_package(Delphes REQUIRED)
 find_package(EDM4HEP REQUIRED)
 find_package(ROOT REQUIRED)
 
+# Detect whether Delphes uses ReadEvent (new) or ReadBlock (old)
+# ReadEvent was introduced in Delphes 3.5.2pre01.
+# Delphes doesn't export a version so checking for the existence of ReadEvent is the only way to detect this.
+file(STRINGS "${DELPHES_INCLUDE_DIR}/classes/DelphesHepMC2Reader.h"
+     _delphes_hepmcreader_content REGEX "ReadEvent")
+if(_delphes_hepmcreader_content)
+  message(STATUS "Delphes: using ReadEvent API (new)")
+  add_compile_definitions(DELPHES_HAS_READ_EVENT)
+else()
+  message(STATUS "Delphes: using ReadBlock API (old)")
+endif()
+
 #--- optional dependencies
 if(BUILD_PYTHIA_READER OR BUILD_EVTGEN_READER)
   find_package(Pythia8 REQUIRED)

--- a/standalone/src/DelphesHepMC2Reader.h
+++ b/standalone/src/DelphesHepMC2Reader.h
@@ -98,7 +98,12 @@ public:
     auto factory = modularDelphes->GetFactory();
     bool goodRead = false;
     while ((goodRead =
-                m_reader->ReadBlock(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)) &&
+#ifdef DELPHES_HAS_READ_EVENT
+                m_reader->ReadEvent(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)
+#else
+                m_reader->ReadBlock(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)
+#endif
+                ) &&
            !m_reader->EventReady()) {
     }
     m_readStopWatch.Stop();

--- a/standalone/src/DelphesHepMC3Reader.h
+++ b/standalone/src/DelphesHepMC3Reader.h
@@ -98,7 +98,12 @@ public:
     auto factory = modularDelphes->GetFactory();
     bool goodRead = false;
     while ((goodRead =
-                m_reader->ReadBlock(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)) &&
+#ifdef DELPHES_HAS_READ_EVENT
+                m_reader->ReadEvent(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)
+#else
+                m_reader->ReadBlock(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)
+#endif
+                ) &&
            !m_reader->EventReady()) {
     }
     m_readStopWatch.Stop();

--- a/standalone/src/DelphesPythia8EvtGenReader.h
+++ b/standalone/src/DelphesPythia8EvtGenReader.h
@@ -132,8 +132,13 @@ public:
     m_treeWriter->Clear();
     auto factory = modularDelphes->GetFactory();
     while (m_reader &&
+#ifdef DELPHES_HAS_READ_EVENT
+           m_reader->ReadEvent(factory, m_allParticleOutputArrayLHEF, m_stableParticleOutputArrayLHEF,
+                               m_partonOutputArrayLHEF) &&
+#else
            m_reader->ReadBlock(factory, m_allParticleOutputArrayLHEF, m_stableParticleOutputArrayLHEF,
                                m_partonOutputArrayLHEF) &&
+#endif
            !m_reader->EventReady())
       ;
 

--- a/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
+++ b/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
@@ -148,8 +148,13 @@ public:
     m_treeWriter->Clear();
     auto factory = modularDelphes->GetFactory();
     while (m_reader &&
+#ifdef DELPHES_HAS_READ_EVENT
+           m_reader->ReadEvent(factory, m_allParticleOutputArrayLHEF, m_stableParticleOutputArrayLHEF,
+                               m_partonOutputArrayLHEF) &&
+#else
            m_reader->ReadBlock(factory, m_allParticleOutputArrayLHEF, m_stableParticleOutputArrayLHEF,
                                m_partonOutputArrayLHEF) &&
+#endif
            !m_reader->EventReady())
       ;
 

--- a/standalone/src/DelphesPythia8Reader.h
+++ b/standalone/src/DelphesPythia8Reader.h
@@ -133,8 +133,13 @@ public:
     m_treeWriter->Clear();
     auto factory = modularDelphes->GetFactory();
     while (reader &&
+#ifdef DELPHES_HAS_READ_EVENT
+           reader->ReadEvent(factory, m_allParticleOutputArrayLHEF, m_stableParticleOutputArrayLHEF,
+                             m_partonOutputArrayLHEF) &&
+#else
            reader->ReadBlock(factory, m_allParticleOutputArrayLHEF, m_stableParticleOutputArrayLHEF,
                              m_partonOutputArrayLHEF) &&
+#endif
            !reader->EventReady())
       ;
 

--- a/standalone/src/DelphesSTDHEPInputReader.h
+++ b/standalone/src/DelphesSTDHEPInputReader.h
@@ -98,7 +98,13 @@ public:
     m_treeWriter->Clear();
     m_readStopWatch.Start();
     auto factory = modularDelphes->GetFactory();
-    while (m_reader->ReadBlock(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)) {
+    while (
+#ifdef DELPHES_HAS_READ_EVENT
+        m_reader->ReadEvent(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)
+#else
+        m_reader->ReadBlock(factory, allParticleOutputArray, stableParticleOutputArray, partonOutputArray)
+#endif
+    ) {
       if (m_reader->EventReady()) {
         m_readStopWatch.Stop();
         m_eventCounter++;


### PR DESCRIPTION
BEGINRELEASENOTES
- Check if ReadEvent (added in https://github.com/delphes/delphes/commit/93e1a6265184179895389125e7f91ddc18a19496  and deprecated in https://github.com/delphes/delphes/pull/195) exists, in that case use it

ENDRELEASENOTES

This is, I think, the best that we can do since there is no way of knowing which Delphes version we are using. By the time this check fails (for example if the reader was removed) we can probably remove the check.