### PR TITLE
Propagate Pythia8 generator weight vector to EDM4hep

### DIFF
--- a/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
+++ b/converter/include/k4SimDelphes/DelphesEDM4HepConverter.h
@@ -94,6 +94,10 @@ public:
    */
   void process(TTree* delphesTree);
 
+  /// Attach generator event weights to the current EventHeader; call after
+  /// process(), before getCollections(). Weight names go in the metadata Frame.
+  void setEventWeights(const std::vector<double>& weights);
+
   /** Get the converted collections and their ownership.
    *
    * NOTE: Since this moves the ownership of the internal collections, this

--- a/converter/src/DelphesEDM4HepConverter.cc
+++ b/converter/src/DelphesEDM4HepConverter.cc
@@ -173,6 +173,18 @@ void DelphesEDM4HepConverter::createEventHeader(const HepMCEvent* delphesEvent) 
   cand.setEventNumber(delphesEvent->Number);
 }
 
+void DelphesEDM4HepConverter::setEventWeights(const std::vector<double>& weights) {
+  auto* collection = getCollection<edm4hep::EventHeaderCollection>(EVENTHEADER_NAME);
+  if (!collection || collection->size() == 0) {
+    std::cerr << "K4SIMDELPHES ERROR: setEventWeights called but no EventHeader exists for this event" << std::endl;
+    return;
+  }
+  auto header = collection->at(0);
+  for (const auto w : weights) {
+    header.addToWeights(w);
+  }
+}
+
 void DelphesEDM4HepConverter::processParticles(const TClonesArray* delphesCollection, std::string const& branch) {
   auto* collection = createCollection<edm4hep::MCParticleCollection>(branch);
 

--- a/examples/data/ee_Z_bbbar_ecm91GeV_weights.cmd
+++ b/examples/data/ee_Z_bbbar_ecm91GeV_weights.cmd
@@ -1,0 +1,63 @@
+! ee -> Z/gamma* -> bbbar at sqrt(s) = 91.188 GeV, with the Pythia8 per-event
+! variation-weight machinery switched on. Exercises the propagation of the
+! generator weight vector into EventHeader.weights and of the weight names into
+! the file-level metadata frame (edm4hep::labels::EventWeightsNames).
+!
+! Without UncertaintyBands:doVariations / VariationFrag:list, Pythia books only
+! the nominal weight and the converter writes neither the weights vector nor the
+! metadata frame. With the settings below it books 53 weights per event.
+!
+! Realistic FCC-ee setup: the stable-particle convention is the tracking-cylinder
+! one, and the variation amplitudes are calibrated so that each is a 1 sigma
+! variation of its measured PDG/HFLAV anchor.
+Random:setSeed = on
+Random:seed = 10
+Main:timesAllowErrors = 5
+
+Init:showChangedSettings = on
+Init:showChangedParticleData = off
+Main:numberOfEvents = 100
+Next:numberCount = 100
+Next:numberShowInfo = 1
+Next:numberShowProcess = 1
+Next:numberShowEvent = 0
+
+Beams:idA = 11
+Beams:idB = -11
+Beams:eCM = 91.188
+
+WeakSingleBoson:ffbar2gmZ = on
+23:onMode = off
+23:onIfAny = 5
+
+PartonLevel:ISR = on
+PartonLevel:FSR = on
+
+! stable-particle convention: decay only inside the tracking cylinder
+ParticleDecays:limitCylinder = on
+ParticleDecays:xyMax = 2250.
+ParticleDecays:zMax = 2500.
+
+! =====================================================================
+! Per-event systematic-variation weights. Each amplitude is calibrated so that
+! the variation shifts its measured anchor observable by exactly 1 sigma of the
+! PDG/HFLAV world average:
+!   frag:rFactB           0.855 +- 0.0326   anchor <x_B> 0.35%        [PDG]
+!   frag:rFactC            1.32 +- 0.151    anchor <x_E(D*)> 1.2%     [PDG]
+!   frag:aLund             0.68 +- 0.0895   anchor <x_B> 0.35%        [PDG]
+!   frag:bLund             0.98 +- 0.0584   anchor <x_B> 0.35%        [PDG]
+!   frag:ptSigma          0.335 +- 0.02     anchor none               [CONVENTIONAL: <x_B> does not respond (0.01 sigma)]
+!   frag:rho              0.217 +- 0.00923  anchor <n(K0)> 1.3%       [PDG (tightest; f(Bs) 8% would allow 0.0209)]
+!   frag:xi               0.081 +- 0.00151  anchor <n(Lambda)> 1.7%   [PDG (tightest; f(b bar.) 13% would allow 0.0081)]
+!   frag:x                0.915 +- 0.085    anchor none               [CONVENTIONAL: <n(K0)> does not respond (0.03 sigma)]
+!   frag:y               0.0275 +- 0.0035   anchor <n(Lambda)> 1.7%   [PDG]
+!   fsr:G2QQ:muRfac         1.0 +- 0.3086   anchor g->cc 13%          [PDG (1 sigma in g->cc; only 0.43 sigma in g->bb)]
+!   fsr:G2QQ:cNS            0.0 +- 0.9814   anchor g->bb 20%          [PDG (1 sigma in g->bb; only 0.24 sigma in g->cc)]
+!
+! The shower band (fsr:muRfac, fsr:cNS) is the conventional 2-point variation:
+! alphaS(MZ) constrains the physical coupling, not the shower's effective one.
+! =====================================================================
+UncertaintyBands:doVariations = on
+UncertaintyBands:List = { fsrRhi fsr:muRfac=2.0, fsrRlo fsr:muRfac=0.5, fsrNShi fsr:cNS=2.0, fsrNSlo fsr:cNS=-2.0, g2qqRhi fsr:G2QQ:muRfac=1.3086, g2qqRlo fsr:G2QQ:muRfac=0.6914, g2qqNShi fsr:G2QQ:cNS=0.9814, g2qqNSlo fsr:G2QQ:cNS=-0.9814 }
+
+VariationFrag:list = { rFactBHi frag:rFactB=0.8876, rFactBLo frag:rFactB=0.8224, rFactCHi frag:rFactC=1.471, rFactCLo frag:rFactC=1.169, aLundHi frag:aLund=0.7695, aLundLo frag:aLund=0.5905, bLundHi frag:bLund=1.0384, bLundLo frag:bLund=0.9216, ptSigmaHi frag:ptSigma=0.355, ptSigmaLo frag:ptSigma=0.315, rhoHi frag:rho=0.22623, rhoLo frag:rho=0.20777, xiHi frag:xi=0.08251, xiLo frag:xi=0.07949, xHi frag:x=1.0, xLo frag:x=0.83, yHi frag:y=0.031, yLo frag:y=0.024 }

--- a/standalone/src/DelphesInputReader.h
+++ b/standalone/src/DelphesInputReader.h
@@ -4,6 +4,7 @@
 #include "TTree.h"
 
 #include <string>
+#include <vector>
 
 class TObjArray;
 class Delphes;
@@ -24,6 +25,13 @@ public:
                          TObjArray* stableParticleOutputArray, TObjArray* partonOutputArray) = 0;
 
   virtual TTree* converterTree() = 0;
+
+  /// Generator event-weight vector of the current event; index 0 is nominal.
+  /// Default empty: no weights beyond EventHeader.weight.
+  virtual std::vector<double> eventWeights() const { return {}; }
+
+  /// Names for eventWeights(), stable across the run (stored once per file).
+  virtual std::vector<std::string> eventWeightNames() const { return {}; }
 };
 
 #endif

--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -2,7 +2,10 @@
 #include "k4SimDelphes/DelphesEDM4HepConverter.h"
 #include "k4SimDelphes/DelphesEDM4HepOutputConfiguration.h"
 
+#include "edm4hep/Constants.h"
+
 #include "podio/Frame.h"
+#include "podio/FrameCategories.h"
 #include "podio/ROOTWriter.h"
 
 #include "ExRootAnalysis/ExRootConfReader.h"
@@ -69,6 +72,13 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
       modularDelphes->ProcessTask();
       edm4hepConverter.process(inputReader.converterTree());
 
+      // Attach the generator weight vector to the EventHeader (Pythia8 readers).
+      // Size 1 means nominal only (already in EventHeader.weight) -> store nothing.
+      const auto evWeights = inputReader.eventWeights();
+      if (evWeights.size() > 1) {
+        edm4hepConverter.setEventWeights(evWeights);
+      }
+
       // Put everything into a Frame and write it out
       podio::Frame frame;
       for (auto& [name, coll] : edm4hepConverter.getCollections()) {
@@ -83,6 +93,17 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
 
     progressBar.Update(eventCounter, eventCounter, true);
     progressBar.Finish();
+
+    // Weight names -> file-level metadata Frame (edm4hep convention)
+    const auto weightNames = inputReader.eventWeightNames();
+    if (weightNames.size() > 1) {
+      std::cout << "k4SimDelphes: storing " << weightNames.size() << " generator event weight names in the metadata frame"
+                << std::endl;
+      podio::Frame metadataFrame;
+      metadataFrame.putParameter(edm4hep::labels::EventWeightsNames, weightNames);
+      podioWriter.writeFrame(metadataFrame, podio::Category::Metadata);
+    }
+
     podioWriter.finish();
     modularDelphes->Finish();
     std::cout << "** Exiting ..." << std::endl;

--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -119,8 +119,8 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
     // Weight names -> file-level metadata Frame (edm4hep convention)
     const auto weightNames = inputReader.eventWeightNames();
     if (weightNames.size() > 1) {
-      std::cout << "k4SimDelphes: storing " << weightNames.size() << " generator event weight names in the metadata frame"
-                << std::endl;
+      std::cout << "k4SimDelphes: storing " << weightNames.size()
+                << " generator event weight names in the metadata frame" << std::endl;
       podio::Frame metadataFrame;
       metadataFrame.putParameter(edm4hep::labels::EventWeightsNames, weightNames);
       podioWriter.writeFrame(metadataFrame, podio::Category::Metadata);

--- a/standalone/src/DelphesPythia8Reader.h
+++ b/standalone/src/DelphesPythia8Reader.h
@@ -179,6 +179,11 @@ public:
 
   TTree* converterTree() override { return m_treeWriter->GetTree(); }
 
+  /// Nominal (index 0) + UncertaintyBands/VariationFrag variation weights.
+  std::vector<double> eventWeights() const override { return m_pythia->info.weightValueVector(); }
+
+  std::vector<std::string> eventWeightNames() const override { return m_pythia->info.weightNameVector(); }
+
 private:
   static constexpr const char* m_appName = "DelphesPythia8";
   std::unique_ptr<Pythia8::Pythia> m_pythia{nullptr};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,14 +45,14 @@ if(DELPHES_CARD)
 
     ADD_COMPARISON_TEST(PythiaResonanceDecayFilter_pp_hhbbyy DelphesPythia8_EDM4HEP ${DELPHES_CARD} ${OUTPUT_CONFIG} pythia_resonance_decay_filter_pp_hhbbyy_output.root ${PROJECT_SOURCE_DIR}/examples/data/tester_pwp8_pp_hh_5f_hhbbyy.cmd --no-delphes)
 
-    # Check that the Pythia8 variation weights reach the EventHeader and that
-    # their names are written to the metadata frame
+    # Check that the Pythia8 variation weights reach the EventHeader and their
+    # names the metadata frame: the *_check test inspects the produced file
     ADD_COMPARISON_TEST(PythiaConverter_ee_Z_bbbar_weights DelphesPythia8_EDM4HEP ${DELPHES_CARD} ${OUTPUT_CONFIG} pythia_converter_output_ee_Z_bbbar_weights.root ${PROJECT_SOURCE_DIR}/examples/data/ee_Z_bbbar_ecm91GeV_weights.cmd --no-delphes)
 
-    set_tests_properties(PythiaConverter_ee_Z_bbbar_weights
-      PROPERTIES
-        PASS_REGULAR_EXPRESSION "k4SimDelphes: storing [0-9]+ generator event weight names"
-    )
+    set_tests_properties(PythiaConverter_ee_Z_bbbar_weights PROPERTIES FIXTURES_SETUP weights_output_file)
+    add_test(NAME PythiaConverter_ee_Z_bbbar_weights_check
+      COMMAND python3 ${PROJECT_SOURCE_DIR}/tests/scripts/check_event_weights.py pythia_converter_output_ee_Z_bbbar_weights.root)
+    set_tests_properties(PythiaConverter_ee_Z_bbbar_weights_check PROPERTIES FIXTURES_REQUIRED weights_output_file)
   endif()
 
   ADD_COMPARISON_TEST(DelphesRootReader_ee_91gev DelphesROOT_EDM4HEP ${DELPHES_CARD} ${OUTPUT_CONFIG} delphes_root_converter_input_reader_test.root ${PROJECT_SOURCE_DIR}/tests/data/gev91ee_zboson_100events.root )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,15 @@ if(DELPHES_CARD)
     ADD_COMPARISON_TEST(PythiaConverter_ee_Z_bbbar DelphesPythia8_EDM4HEP ${DELPHES_CARD} ${OUTPUT_CONFIG} pythia_converter_output_ee_Z_bbbar.root ${PROJECT_SOURCE_DIR}/examples/data/ee_Z_bbbar_ecm91GeV.cmd)
 
     ADD_COMPARISON_TEST(PythiaResonanceDecayFilter_pp_hhbbyy DelphesPythia8_EDM4HEP ${DELPHES_CARD} ${OUTPUT_CONFIG} pythia_resonance_decay_filter_pp_hhbbyy_output.root ${PROJECT_SOURCE_DIR}/examples/data/tester_pwp8_pp_hh_5f_hhbbyy.cmd --no-delphes)
+
+    # Check that the Pythia8 variation weights reach the EventHeader and that
+    # their names are written to the metadata frame
+    ADD_COMPARISON_TEST(PythiaConverter_ee_Z_bbbar_weights DelphesPythia8_EDM4HEP ${DELPHES_CARD} ${OUTPUT_CONFIG} pythia_converter_output_ee_Z_bbbar_weights.root ${PROJECT_SOURCE_DIR}/examples/data/ee_Z_bbbar_ecm91GeV_weights.cmd --no-delphes)
+
+    set_tests_properties(PythiaConverter_ee_Z_bbbar_weights
+      PROPERTIES
+        PASS_REGULAR_EXPRESSION "k4SimDelphes: storing [0-9]+ generator event weight names"
+    )
   endif()
 
   ADD_COMPARISON_TEST(DelphesRootReader_ee_91gev DelphesROOT_EDM4HEP ${DELPHES_CARD} ${OUTPUT_CONFIG} delphes_root_converter_input_reader_test.root ${PROJECT_SOURCE_DIR}/tests/data/gev91ee_zboson_100events.root )

--- a/tests/scripts/check_event_weights.py
+++ b/tests/scripts/check_event_weights.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Check that an EDM4hep file contains generator event weights: every event
+has a non-trivial EventHeader.weights vector with weights[0] equal to the
+scalar EventHeader.weight, and the metadata frame holds a matching
+EventWeightNames list.
+
+Usage: check_event_weights.py <edm4hep_file>
+"""
+
+import sys
+
+import podio.root_io
+
+
+def fail(msg):
+    print(f"check_event_weights: FAILURE: {msg}")
+    sys.exit(1)
+
+
+reader = podio.root_io.Reader(sys.argv[1])
+
+n_events = 0
+n_weights = 0
+for frame in reader.get("events"):
+    header = frame.get("EventHeader")[0]
+    weights = list(header.getWeights())
+    if len(weights) < 2:
+        fail(f"event {n_events}: weights vector has size {len(weights)}, expected > 1")
+    if weights[0] != header.getWeight():
+        fail(f"event {n_events}: weights[0] = {weights[0]} != EventHeader.weight = {header.getWeight()}")
+    n_weights = len(weights)
+    n_events += 1
+
+if n_events == 0:
+    fail("no events in file")
+
+names = []
+for frame in reader.get("metadata"):
+    names = list(frame.get_parameter("EventWeightNames"))
+    break
+if len(names) != n_weights:
+    fail(f"EventWeightNames has {len(names)} entries but the weights vector has {n_weights}")
+
+print(f"check_event_weights: OK: {n_events} events x {n_weights} weights, "
+      f"{len(names)} names in metadata, weights[0] == EventHeader.weight everywhere")


### PR DESCRIPTION
`DelphesPythia8_EDM4HEP` currently stores only the nominal event weight.


This PR implements storing the full `pythia.info` weight vector in `EventHeader.weights` and
and the weight labels in the metadata under`edm4hep::labels::EventWeightsNames`. 

`examples/data/ee_Z_bbbar_ecm91GeV_weights.cmd` is an example card with the weight machinery enabled.

