### PR TITLE
Support RNTuple-based EDM4hep output from standalone executables

### DIFF
--- a/standalone/CMakeLists.txt
+++ b/standalone/CMakeLists.txt
@@ -1,28 +1,28 @@
 # build executable and put it into bin/
 add_executable(DelphesROOT_EDM4HEP src/DelphesROOT_EDM4HEP.cpp)
-target_link_libraries(DelphesROOT_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO ROOT::Physics)
+target_link_libraries(DelphesROOT_EDM4HEP DelphesEDM4HepConverter podio::podioIO ROOT::Physics)
 install(TARGETS DelphesROOT_EDM4HEP DESTINATION bin)
 
 if(BUILD_HEPMC_READER)
   # build executable and put it into bin/
   add_executable(DelphesHepMC2_EDM4HEP src/DelphesHepMC2_EDM4HEP.cpp)
-  target_link_libraries(DelphesHepMC2_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO)
+  target_link_libraries(DelphesHepMC2_EDM4HEP DelphesEDM4HepConverter podio::podioIO)
   install(TARGETS DelphesHepMC2_EDM4HEP DESTINATION bin)
 
   add_executable(DelphesHepMC3_EDM4HEP src/DelphesHepMC3_EDM4HEP.cpp)
-  target_link_libraries(DelphesHepMC3_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO)
+  target_link_libraries(DelphesHepMC3_EDM4HEP DelphesEDM4HepConverter podio::podioIO)
   install(TARGETS DelphesHepMC3_EDM4HEP DESTINATION bin)
 endif()
 
 # build executable and put it into bin/
 add_executable(DelphesSTDHEP_EDM4HEP src/DelphesSTDHEP_EDM4HEP.cpp)
-target_link_libraries(DelphesSTDHEP_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO ${DELPHES_LIBRARY})
+target_link_libraries(DelphesSTDHEP_EDM4HEP DelphesEDM4HepConverter podio::podioIO ${DELPHES_LIBRARY})
 install(TARGETS DelphesSTDHEP_EDM4HEP DESTINATION bin)
 
 if(BUILD_PYTHIA_READER)
   add_executable(DelphesPythia8_EDM4HEP src/DelphesPythia8_EDM4HEP.cpp)
   target_include_directories(DelphesPythia8_EDM4HEP PRIVATE ${PYTHIA8_INCLUDE_DIRS})
-  target_link_libraries(DelphesPythia8_EDM4HEP DelphesEDM4HepConverter podio::podioRootIO ${PYTHIA8_LIBRARIES} ${DELPHES_LIBRARY})
+  target_link_libraries(DelphesPythia8_EDM4HEP DelphesEDM4HepConverter podio::podioIO ${PYTHIA8_LIBRARIES} ${DELPHES_LIBRARY})
   install(TARGETS DelphesPythia8_EDM4HEP DESTINATION bin)
 endif()
 
@@ -39,7 +39,7 @@ if(BUILD_EVTGEN_READER)
   target_include_directories(DelphesPythia8EvtGen_EDM4HEP PRIVATE ${PYTHIA8_INCLUDE_DIRS} )
   target_link_libraries(DelphesPythia8EvtGen_EDM4HEP
                         DelphesEDM4HepConverter
-                        podio::podioRootIO
+                        podio::podioIO
                         ${PYTHIA8_LIBRARIES}
                         ${DELPHES_LIBRARY}
                         EvtGen::EvtGen
@@ -51,7 +51,7 @@ if(BUILD_EVTGEN_READER)
   target_link_libraries(DelphesPythia8EvtGen_EDM4HEP_k4Interface
                         PythiaEvtGen_Interface
                         DelphesEDM4HepConverter
-                        podio::podioRootIO
+                        podio::podioIO
                         ${PYTHIA8_LIBRARIES}
                         ${DELPHES_LIBRARY}
                         EvtGen::EvtGen

--- a/standalone/src/DelphesHepMC2Reader.h
+++ b/standalone/src/DelphesHepMC2Reader.h
@@ -85,8 +85,9 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file [input_file(s)]\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format (TTree by default; set "
-         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
+         << "output_file - output file in ROOT format (TTree by default; pass "
+         << "--rntuple, or set PODIO_DEFAULT_WRITE_RNTUPLE=1, to write RNTuple\n"
+         << "instead),\n"
          << "input_file(s) - input file(s) in HepMC format,\n"
          << "with no input_file, or when input_file is -, read standard input.\n";
     return sstr.str();

--- a/standalone/src/DelphesHepMC2Reader.h
+++ b/standalone/src/DelphesHepMC2Reader.h
@@ -85,7 +85,8 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file [input_file(s)]\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format,\n"
+         << "output_file - output file in ROOT format (TTree by default; set "
+         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
          << "input_file(s) - input file(s) in HepMC format,\n"
          << "with no input_file, or when input_file is -, read standard input.\n";
     return sstr.str();

--- a/standalone/src/DelphesHepMC3Reader.h
+++ b/standalone/src/DelphesHepMC3Reader.h
@@ -85,8 +85,9 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file [input_file(s)]\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format (TTree by default; set "
-         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
+         << "output_file - output file in ROOT format (TTree by default; pass "
+         << "--rntuple, or set PODIO_DEFAULT_WRITE_RNTUPLE=1, to write RNTuple\n"
+         << "instead),\n"
          << "input_file(s) - input file(s) in HepMC format,\n"
          << "with no input_file, or when input_file is -, read standard input.\n";
     return sstr.str();

--- a/standalone/src/DelphesHepMC3Reader.h
+++ b/standalone/src/DelphesHepMC3Reader.h
@@ -85,7 +85,8 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file [input_file(s)]\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format,\n"
+         << "output_file - output file in ROOT format (TTree by default; set "
+         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
          << "input_file(s) - input file(s) in HepMC format,\n"
          << "with no input_file, or when input_file is -, read standard input.\n";
     return sstr.str();

--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -36,17 +36,18 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
       args.push_back(argv[i]);
     }
   }
-  const int newArgc = static_cast<int>(args.size());
-  char** const newArgv = args.data();
+  const int positionalArgc = static_cast<int>(args.size());
+  char** const positionalArgv = args.data();
 
   // We can't make this a unique_ptr because it interferes with whatever ROOT is
   // doing under the hood to clean up
   auto* modularDelphes = new Delphes("Delphes");
-  const auto outputFile = inputReader.init(modularDelphes, newArgc, newArgv);
+  const auto outputFile = inputReader.init(modularDelphes, positionalArgc, positionalArgv);
   if (outputFile.empty()) {
     // Check if the user requested the help, and print the usage message and
     // return succesfully in that case
-    if (newArgc > 1 && (newArgv[1] == std::string_view("--help") || newArgv[1] == std::string_view("-h"))) {
+    if (positionalArgc > 1 &&
+        (positionalArgv[1] == std::string_view("--help") || positionalArgv[1] == std::string_view("-h"))) {
       std::cout << inputReader.getUsage() << std::endl;
       return 0;
     }
@@ -61,11 +62,11 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
   signal(SIGINT, SignalHandler);
   try {
     auto confReader = std::make_unique<ExRootConfReader>();
-    confReader->ReadFile(newArgv[1]);
+    confReader->ReadFile(positionalArgv[1]);
     modularDelphes->SetConfReader(confReader.get());
 
     const auto branches = getBranchSettings(confReader->GetParam("TreeWriter::Branch"));
-    const auto edm4hepOutputSettings = getEDM4hepOutputSettings(newArgv[2]);
+    const auto edm4hepOutputSettings = getEDM4hepOutputSettings(positionalArgv[2]);
     DelphesEDM4HepConverter edm4hepConverter(branches, edm4hepOutputSettings,
                                              confReader->GetDouble("ParticlePropagator::Bz", 0));
 

--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -12,6 +12,8 @@
 #include <iostream>
 #include <memory>
 #include <signal.h>
+#include <string_view>
+#include <vector>
 
 static bool interrupted = false;
 void SignalHandler(int /*si*/) { interrupted = true; }
@@ -19,14 +21,32 @@ void SignalHandler(int /*si*/) { interrupted = true; }
 int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
   using namespace k4SimDelphes;
 
+  // Look for an optional "--rntuple" flag, which can appear anywhere among the
+  // arguments, to request writing the EDM4hep output with the RNTuple backend
+  // instead of the default TTree based one. It is stripped out before the
+  // purely positional argument parsing done by the reader below.
+  std::string writerType = "default";
+  std::vector<char*> args;
+  args.reserve(argc);
+  args.push_back(argv[0]);
+  for (int i = 1; i < argc; ++i) {
+    if (std::string_view(argv[i]) == "--rntuple") {
+      writerType = "rntuple";
+    } else {
+      args.push_back(argv[i]);
+    }
+  }
+  const int newArgc = static_cast<int>(args.size());
+  char** const newArgv = args.data();
+
   // We can't make this a unique_ptr because it interferes with whatever ROOT is
   // doing under the hood to clean up
   auto* modularDelphes = new Delphes("Delphes");
-  const auto outputFile = inputReader.init(modularDelphes, argc, argv);
+  const auto outputFile = inputReader.init(modularDelphes, newArgc, newArgv);
   if (outputFile.empty()) {
     // Check if the user requested the help, and print the usage message and
     // return succesfully in that case
-    if (argc > 1 && (argv[1] == std::string_view("--help") || argv[1] == std::string_view("-h"))) {
+    if (newArgc > 1 && (newArgv[1] == std::string_view("--help") || newArgv[1] == std::string_view("-h"))) {
       std::cout << inputReader.getUsage() << std::endl;
       return 0;
     }
@@ -34,19 +54,18 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
     return 1;
   }
 
-  // Selects between the TTree and RNTuple based backends depending on the
-  // PODIO_DEFAULT_WRITE_RNTUPLE environment variable (unset/empty -> TTree,
-  // anything else -> RNTuple).
-  auto podioWriter = podio::makeWriter(outputFile);
+  // "default" falls back to the PODIO_DEFAULT_WRITE_RNTUPLE environment
+  // variable (unset/empty -> TTree, anything else -> RNTuple).
+  auto podioWriter = podio::makeWriter(outputFile, writerType);
 
   signal(SIGINT, SignalHandler);
   try {
     auto confReader = std::make_unique<ExRootConfReader>();
-    confReader->ReadFile(argv[1]);
+    confReader->ReadFile(newArgv[1]);
     modularDelphes->SetConfReader(confReader.get());
 
     const auto branches = getBranchSettings(confReader->GetParam("TreeWriter::Branch"));
-    const auto edm4hepOutputSettings = getEDM4hepOutputSettings(argv[2]);
+    const auto edm4hepOutputSettings = getEDM4hepOutputSettings(newArgv[2]);
     DelphesEDM4HepConverter edm4hepConverter(branches, edm4hepOutputSettings,
                                              confReader->GetDouble("ParticlePropagator::Bz", 0));
 

--- a/standalone/src/DelphesMain.h
+++ b/standalone/src/DelphesMain.h
@@ -3,7 +3,7 @@
 #include "k4SimDelphes/DelphesEDM4HepOutputConfiguration.h"
 
 #include "podio/Frame.h"
-#include "podio/ROOTWriter.h"
+#include "podio/Writer.h"
 
 #include "ExRootAnalysis/ExRootConfReader.h"
 #include "ExRootAnalysis/ExRootProgressBar.h"
@@ -16,7 +16,6 @@
 static bool interrupted = false;
 void SignalHandler(int /*si*/) { interrupted = true; }
 
-template <typename WriterT = podio::ROOTWriter>
 int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
   using namespace k4SimDelphes;
 
@@ -35,7 +34,10 @@ int doit(int argc, char* argv[], DelphesInputReader& inputReader) {
     return 1;
   }
 
-  WriterT podioWriter(outputFile);
+  // Selects between the TTree and RNTuple based backends depending on the
+  // PODIO_DEFAULT_WRITE_RNTUPLE environment variable (unset/empty -> TTree,
+  // anything else -> RNTuple).
+  auto podioWriter = podio::makeWriter(outputFile);
 
   signal(SIGINT, SignalHandler);
   try {

--- a/standalone/src/DelphesPythia8EvtGenReader.h
+++ b/standalone/src/DelphesPythia8EvtGenReader.h
@@ -120,7 +120,8 @@ public:
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
          << "pythia_card - Pythia8 configuration file,\n"
-         << "output_file - output file in ROOT format,\n"
+         << "output_file - output file in ROOT format (TTree by default; set "
+         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
          << "DECAY.DEC - EvtGen full decay file,\n"
          << "evt.pdl - EvtGen particle list,\n"
          << "user.dec - EvtGen user decay file.\n";

--- a/standalone/src/DelphesPythia8EvtGenReader.h
+++ b/standalone/src/DelphesPythia8EvtGenReader.h
@@ -120,8 +120,9 @@ public:
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
          << "pythia_card - Pythia8 configuration file,\n"
-         << "output_file - output file in ROOT format (TTree by default; set "
-         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
+         << "output_file - output file in ROOT format (TTree by default; pass "
+         << "--rntuple, or set PODIO_DEFAULT_WRITE_RNTUPLE=1, to write RNTuple\n"
+         << "instead),\n"
          << "DECAY.DEC - EvtGen full decay file,\n"
          << "evt.pdl - EvtGen particle list,\n"
          << "user.dec - EvtGen user decay file.\n";

--- a/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
+++ b/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
@@ -136,7 +136,8 @@ public:
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
          << "pythia_card - Pythia8 configuration file,\n"
-         << "output_file - output file in ROOT format,\n"
+         << "output_file - output file in ROOT format (TTree by default; set "
+         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
          << "DECAY.DEC - EvtGen full decay file,\n"
          << "evt.pdl - EvtGen particle list,\n"
          << "user.dec - EvtGen user decay file.\n";

--- a/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
+++ b/standalone/src/DelphesPythia8EvtGenReader_k4Interface.h
@@ -136,8 +136,9 @@ public:
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
          << "pythia_card - Pythia8 configuration file,\n"
-         << "output_file - output file in ROOT format (TTree by default; set "
-         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
+         << "output_file - output file in ROOT format (TTree by default; pass "
+         << "--rntuple, or set PODIO_DEFAULT_WRITE_RNTUPLE=1, to write RNTuple\n"
+         << "instead),\n"
          << "DECAY.DEC - EvtGen full decay file,\n"
          << "evt.pdl - EvtGen particle list,\n"
          << "user.dec - EvtGen user decay file.\n";

--- a/standalone/src/DelphesPythia8Reader.h
+++ b/standalone/src/DelphesPythia8Reader.h
@@ -124,7 +124,8 @@ public:
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
          << "pythia_card - Pythia8 configuration file,\n"
-         << "output_file - output file in ROOT format.\n";
+         << "output_file - output file in ROOT format (TTree by default; set "
+         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead).\n";
     return sstr.str();
   }
 

--- a/standalone/src/DelphesPythia8Reader.h
+++ b/standalone/src/DelphesPythia8Reader.h
@@ -124,8 +124,9 @@ public:
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
          << "pythia_card - Pythia8 configuration file,\n"
-         << "output_file - output file in ROOT format (TTree by default; set "
-         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead).\n";
+         << "output_file - output file in ROOT format (TTree by default; pass "
+         << "--rntuple, or set PODIO_DEFAULT_WRITE_RNTUPLE=1, to write RNTuple\n"
+         << "instead).\n";
     return sstr.str();
   }
 

--- a/standalone/src/DelphesRootReader.h
+++ b/standalone/src/DelphesRootReader.h
@@ -58,8 +58,9 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file input_file(s)\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format (TTree by default; set "
-         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
+         << "output_file - output file in ROOT format (TTree by default; pass "
+         << "--rntuple, or set PODIO_DEFAULT_WRITE_RNTUPLE=1, to write RNTuple\n"
+         << "instead),\n"
          << "input_file(s) - input file(s) in ROOT format\n";
     return sstr.str();
   }

--- a/standalone/src/DelphesRootReader.h
+++ b/standalone/src/DelphesRootReader.h
@@ -58,7 +58,8 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file input_file(s)\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format\n"
+         << "output_file - output file in ROOT format (TTree by default; set "
+         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
          << "input_file(s) - input file(s) in ROOT format\n";
     return sstr.str();
   }

--- a/standalone/src/DelphesSTDHEPInputReader.h
+++ b/standalone/src/DelphesSTDHEPInputReader.h
@@ -86,7 +86,8 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file [input_file(s)]\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format,\n"
+         << "output_file - output file in ROOT format (TTree by default; set "
+         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
          << "input_file(s) - input file(s) in STDHEP format,\n"
          << "with no input_file, or when input_file is -, read standard input.\n";
     return sstr.str();

--- a/standalone/src/DelphesSTDHEPInputReader.h
+++ b/standalone/src/DelphesSTDHEPInputReader.h
@@ -86,8 +86,9 @@ public:
     sstr << "Usage: " << m_appName << " config_file output_config_file output_file [input_file(s)]\n"
          << "config_file - configuration file in Tcl format,\n"
          << "output_config_file - configuration file steering the content of the edm4hep output in Tcl format,\n"
-         << "output_file - output file in ROOT format (TTree by default; set "
-         << "PODIO_DEFAULT_WRITE_RNTUPLE=1 to write RNTuple instead),\n"
+         << "output_file - output file in ROOT format (TTree by default; pass "
+         << "--rntuple, or set PODIO_DEFAULT_WRITE_RNTUPLE=1, to write RNTuple\n"
+         << "instead),\n"
          << "input_file(s) - input file(s) in STDHEP format,\n"
          << "with no input_file, or when input_file is -, read standard input.\n";
     return sstr.str();


### PR DESCRIPTION
Switch the standalone Delphes-to-EDM4hep executables from a hardcoded `podio::ROOTWriter` to `podio::makeWriter()`, so any of them can write RNTuple-based files by setting `PODIO_DEFAULT_WRITE_RNTUPLE=1` instead of the default TTree-based file, with no other usage change.

Link `podio::podioIO` instead of `podio::podioRootIO` since `makeWriter()` lives in `libpodioIO.so`, and document the new env var in each executable's `--help` text.